### PR TITLE
Add Status tab with auto-revival, latency-based smart routing, and cost tracking

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -501,8 +501,8 @@
                             </svg>
                             <span class="text-sm">API Keys</span>
                         </button>
-                        <button 
-                            onclick="showTab('logs')" 
+                        <button
+                            onclick="showTab('logs')"
                             class="tab-btn py-3 px-2 border-b-2 border-transparent text-muted-foreground hover:text-foreground hover:border-border transition-colors flex items-center space-x-2"
                             data-tab="logs"
                         >
@@ -510,6 +510,16 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                             </svg>
                             <span class="text-sm">API Logs</span>
+                        </button>
+                        <button
+                            onclick="showTab('status')"
+                            class="tab-btn py-3 px-2 border-b-2 border-transparent text-muted-foreground hover:text-foreground hover:border-border transition-colors flex items-center space-x-2"
+                            data-tab="status"
+                        >
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                            </svg>
+                            <span class="text-sm">Status</span>
                         </button>
                     </nav>
                     
@@ -643,6 +653,24 @@
                 <!-- Status Messages -->
                 <div id="envSuccess" class="hidden bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-md mt-4"></div>
                 <div id="envError" class="hidden bg-destructive/10 border border-destructive/20 text-destructive px-4 py-3 rounded-md mt-4"></div>
+            </div>
+
+            <div id="status" class="tab-content hidden">
+                <div class="section-header flex items-center justify-between">
+                    <div>
+                        <h2 class="text-lg font-semibold text-foreground">Gateway Status</h2>
+                        <p class="text-muted-foreground text-xs mt-1">Named keys, quota usage, dead keys &middot; auto-refresh every 10s</p>
+                    </div>
+                    <div class="flex items-center space-x-2">
+                        <span id="statusUpdated" class="text-xs text-muted-foreground">—</span>
+                        <button onclick="loadStatus()" class="btn btn-secondary px-3 py-1 text-xs">Refresh</button>
+                        <button onclick="clearAllQuarantine()" class="btn btn-secondary px-3 py-1 text-xs">Clear Dead Keys</button>
+                    </div>
+                </div>
+
+                <div id="statusContent" class="space-y-4">
+                    <div class="text-muted-foreground text-sm py-8 text-center">Loading status…</div>
+                </div>
             </div>
 
             <!-- Logs Tab -->
@@ -1226,7 +1254,252 @@
         
         let originalValues = {};
         let keyUsageData = {};
-        
+
+        let statusAutoRefresh = null;
+        let statusData = null;
+        let latencyData = null;
+        let costData = null;
+
+        const QUOTA_LIMITS = {
+            openrouter: 50,
+            omniroute: 300,
+            gemini: 50,
+            mistral: 100,
+            groq: 14,
+            opencoderouter: 1000
+        };
+
+        async function loadStatus() {
+            try {
+                const [statusRes, latencyRes, costRes] = await Promise.all([
+                    fetch('/admin/api/status'),
+                    fetch('/admin/api/latency').catch(() => ({ ok: false })),
+                    fetch('/admin/api/cost').catch(() => ({ ok: false }))
+                ]);
+                if (!statusRes.ok) throw new Error('HTTP ' + statusRes.status);
+                statusData = await statusRes.json();
+                if (latencyRes.ok) latencyData = await latencyRes.json();
+                if (costRes.ok) costData = await costRes.json();
+                renderStatus();
+            } catch (e) {
+                document.getElementById('statusContent').innerHTML = '<div class="text-destructive text-sm py-4">Failed to load status: ' + e.message + '</div>';
+            }
+        }
+
+        async function runAutoRevival() {
+            try {
+                const res = await fetch('/admin/api/revival/run', { method: 'POST' });
+                if (res.ok) {
+                    const r = await res.json();
+                    showSuccessToast('Revival: checked ' + r.checked + ', revived ' + r.revived);
+                    loadStatus();
+                } else {
+                    showErrorToast('Revival failed');
+                }
+            } catch (e) {
+                showErrorToast('Error: ' + e.message);
+            }
+        }
+
+        function renderStatus() {
+            if (!statusData) return;
+            const c = document.getElementById('statusContent');
+            const t = statusData.totals || {};
+            const dk = statusData.dead_keys || [];
+            const u = statusData.usage_24h || {};
+            const nk = statusData.named_keys || {};
+
+            let html = '';
+
+            html += '<div class="grid grid-cols-2 md:grid-cols-4 gap-3">';
+            html += statCard('Providers', t.providers || 0, 'blue');
+            html += statCard('Named Keys', t.named_keys || 0, 'blue');
+            html += statCard('Dead Keys', dk.length, dk.length > 0 ? 'red' : 'green');
+            html += statCard('Requests (24h)', t.total_requests_24h || 0, 'blue');
+            html += '</div>';
+
+            if (dk.length > 0) {
+                html += '<div class="card p-4 border border-destructive/30 bg-destructive/5">';
+                html += '<h3 class="text-sm font-semibold text-destructive mb-2">⚠ Dead Keys (quarantined 24h)</h3>';
+                html += '<div class="space-y-1 text-xs">';
+                dk.forEach(d => {
+                    const expiresIn = Math.max(0, Math.round((d.expiresAt - Date.now()) / 60000));
+                    const apiType = d.apiType || 'openai';
+                    const name = (nk[apiType] && nk[apiType][d.key]) || d.key;
+                    html += '<div class="flex items-center justify-between font-mono">';
+                    html += '<span>' + escapeHtml(name) + ' <span class="text-muted-foreground">(HTTP ' + d.statusCode + ')</span></span>';
+                    html += '<span class="text-destructive">expires in ' + expiresIn + ' min</span>';
+                    html += '</div>';
+                });
+                html += '</div>';
+                html += '<div class="flex justify-end">';
+                html += '<button onclick="runAutoRevival()" class="btn btn-secondary px-3 py-1 text-xs">↻ Run Auto-Revival Now</button>';
+                html += '</div></div>';
+            }
+
+            const providerOrder = ['openrouter', 'omniroute', 'gemini', 'mistral', 'groq', 'opencoderouter'];
+            providerOrder.forEach(prov => {
+                const keys = u[prov] || [];
+                if (keys.length === 0 && !nk[prov]) return;
+                const quota = QUOTA_LIMITS[prov] || 100;
+                const totalUses = keys.reduce((s, k) => s + k.count, 0);
+                const pct = Math.min(100, Math.round((totalUses / quota) * 100));
+                const barColor = pct >= 90 ? 'bg-destructive' : pct >= 70 ? 'bg-yellow-500' : 'bg-green-500';
+                html += '<div class="card p-4">';
+                html += '<div class="flex items-center justify-between mb-2">';
+                html += '<h3 class="text-sm font-semibold text-foreground capitalize">' + prov + '</h3>';
+                html += '<span class="text-xs text-muted-foreground">' + totalUses + ' / ' + quota + ' req/day</span>';
+                html += '</div>';
+                html += '<div class="w-full bg-muted rounded-full h-2 mb-3"><div class="' + barColor + ' h-2 rounded-full transition-all" style="width:' + pct + '%"></div></div>';
+                if (keys.length > 0) {
+                    html += '<div class="space-y-1">';
+                    keys.slice(0, 8).forEach(k => {
+                        const kpct = Math.min(100, Math.round((k.count / quota) * 100));
+                        const kbar = kpct >= 90 ? 'bg-destructive' : kpct >= 70 ? 'bg-yellow-500' : 'bg-green-500';
+                        const rl = k.rate_limited > 0 ? ' <span class="text-destructive">(' + k.rate_limited + 'x 429)</span>' : '';
+                        const dead = dk.some(d => d.key === k.key) ? ' <span class="text-destructive">💀</span>' : '';
+                        html += '<div class="flex items-center gap-2 text-xs">';
+                        html += '<span class="font-mono flex-1 truncate">' + escapeHtml(k.name) + dead + '</span>';
+                        html += '<span class="w-12 text-right text-muted-foreground">' + k.count + '</span>';
+                        html += '<div class="w-20 bg-muted rounded-full h-1.5"><div class="' + kbar + ' h-1.5 rounded-full" style="width:' + kpct + '%"></div></div>';
+                        html += '<span class="w-12 text-right">' + rl + '</span>';
+                        html += '</div>';
+                    });
+                    if (keys.length > 8) {
+                        html += '<div class="text-xs text-muted-foreground mt-1">+' + (keys.length - 8) + ' more…</div>';
+                    }
+                }
+                html += '</div>';
+            });
+
+            if (Object.keys(nk).length === 0 && dk.length === 0) {
+                html += '<div class="card p-8 text-center text-muted-foreground text-sm">No usage data yet. Make some API calls to populate this view.</div>';
+            }
+
+            renderSmartRouting(c, nk);
+            renderCostSummary(c);
+
+            c.innerHTML = html;
+            document.getElementById('statusUpdated').textContent = 'Updated ' + new Date().toLocaleTimeString();
+        }
+
+        function renderSmartRouting(container, namedKeys) {
+            if (!latencyData || !latencyData.stats || Object.keys(latencyData.stats).length === 0) {
+                return;
+            }
+            const stats = latencyData.stats;
+            const entries = Object.entries(stats).filter(([k, v]) => v && v.samples > 0)
+                .sort((a, b) => a[1].avg - b[1].avg);
+            if (entries.length === 0) return;
+
+            let html = '<div class="card p-4 border-l-4 border-l-blue-500">';
+            html += '<div class="flex items-center justify-between mb-3">';
+            html += '<h3 class="text-sm font-semibold text-foreground">⚡ Smart Routing — Latency Rank</h3>';
+            html += '<span class="text-xs text-muted-foreground">fastest key picked first · auto-updated</span>';
+            html += '</div>';
+            html += '<div class="space-y-1">';
+            entries.forEach(([key, s], i) => {
+                const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '  ';
+                const found = Object.values(namedKeys).find(p => p && p[key]);
+                const name = (found && found[key]) || (key.length > 16 ? key.substring(0, 8) + '…' + key.substring(key.length - 4) : key);
+                const color = s.avg < 2000 ? 'text-green-600' : s.avg < 5000 ? 'text-yellow-600' : 'text-destructive';
+                html += '<div class="flex items-center gap-3 text-xs font-mono">';
+                html += '<span class="w-4">' + medal + '</span>';
+                html += '<span class="flex-1 truncate">' + escapeHtml(name) + '</span>';
+                html += '<span class="w-20 text-right ' + color + '">' + s.avg + 'ms avg</span>';
+                html += '<span class="w-20 text-right text-muted-foreground">p50: ' + s.p50 + 'ms</span>';
+                html += '<span class="w-20 text-right text-muted-foreground">p95: ' + s.p95 + 'ms</span>';
+                html += '<span class="w-12 text-right text-muted-foreground">' + s.samples + '×</span>';
+                html += '</div>';
+            });
+            html += '</div></div>';
+            container.insertAdjacentHTML('beforeend', html);
+        }
+
+        function renderCostSummary(container) {
+            if (!costData || !costData.summary || costData.summary.total.calls === 0) {
+                return;
+            }
+            const s = costData.summary;
+            const t = s.total;
+            let html = '<div class="card p-4 border-l-4 border-l-green-500">';
+            html += '<div class="flex items-center justify-between mb-3">';
+            html += '<h3 class="text-sm font-semibold text-foreground">💰 Cost & Token Usage (24h)</h3>';
+            html += '<span class="text-xs text-muted-foreground">' + t.calls + ' calls · $' + t.cost.toFixed(4) + ' estimated</span>';
+            html += '</div>';
+            html += '<div class="grid grid-cols-3 gap-3 mb-3">';
+            html += '<div><div class="text-xs text-muted-foreground">Total Tokens</div><div class="text-lg font-semibold">' + (t.tokensIn + t.tokensOut).toLocaleString() + '</div></div>';
+            html += '<div><div class="text-xs text-muted-foreground">Input</div><div class="text-lg font-semibold">' + t.tokensIn.toLocaleString() + '</div></div>';
+            html += '<div><div class="text-xs text-muted-foreground">Output</div><div class="text-lg font-semibold">' + t.tokensOut.toLocaleString() + '</div></div>';
+            html += '</div>';
+            html += '<div class="text-xs font-medium text-foreground mb-1">By Provider</div>';
+            html += '<div class="space-y-1 mb-3">';
+            Object.entries(s.byProvider).sort((a, b) => b[1].calls - a[1].calls).forEach(([p, d]) => {
+                html += '<div class="flex items-center gap-2 text-xs">';
+                html += '<span class="font-mono flex-1 capitalize">' + escapeHtml(p) + '</span>';
+                html += '<span class="w-20 text-right text-muted-foreground">' + (d.tokensIn + d.tokensOut).toLocaleString() + ' tok</span>';
+                html += '<span class="w-12 text-right">' + d.calls + '×</span>';
+                html += '</div>';
+            });
+            html += '</div>';
+            html += '<div class="text-xs font-medium text-foreground mb-1">By Model</div>';
+            html += '<div class="space-y-1">';
+            Object.entries(s.byModel).sort((a, b) => b[1].calls - a[1].calls).slice(0, 8).forEach(([m, d]) => {
+                html += '<div class="flex items-center gap-2 text-xs">';
+                html += '<span class="font-mono flex-1 truncate">' + escapeHtml(m) + '</span>';
+                html += '<span class="w-20 text-right text-muted-foreground">' + (d.tokensIn + d.tokensOut).toLocaleString() + ' tok</span>';
+                html += '<span class="w-12 text-right">' + d.calls + '×</span>';
+                html += '</div>';
+            });
+            html += '</div></div>';
+            container.insertAdjacentHTML('beforeend', html);
+        }
+
+        function statCard(label, value, color) {
+            const colorMap = {
+                blue: 'text-blue-600',
+                green: 'text-green-600',
+                red: 'text-destructive'
+            };
+            return '<div class="card p-3"><div class="text-xs text-muted-foreground">' + label + '</div><div class="text-2xl font-semibold ' + (colorMap[color] || 'text-foreground') + '">' + value + '</div></div>';
+        }
+
+        function escapeHtml(s) {
+            return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+        }
+
+        async function clearAllQuarantine() {
+            if (!confirm('Clear all dead keys? They will become usable again immediately.')) return;
+            try {
+                const res = await fetch('/admin/api/quarantine/clear', { method: 'POST', headers: {'Content-Type':'application/json'}, body: '{}' });
+                if (res.ok) {
+                    showSuccessToast('Dead keys cleared');
+                    loadStatus();
+                } else {
+                    showErrorToast('Failed to clear');
+                }
+            } catch (e) {
+                showErrorToast('Error: ' + e.message);
+            }
+        }
+
+        function startStatusAutoRefresh() {
+            if (statusAutoRefresh) return;
+            loadStatus();
+            statusAutoRefresh = setInterval(loadStatus, 10000);
+        }
+
+        function stopStatusAutoRefresh() {
+            if (statusAutoRefresh) { clearInterval(statusAutoRefresh); statusAutoRefresh = null; }
+        }
+
+        const _origShowTab = showTab;
+        showTab = function(tabName) {
+            _origShowTab(tabName);
+            if (tabName === 'status') startStatusAutoRefresh();
+            else stopStatusAutoRefresh();
+        };
+
         function renderEnvVars() {
             
             // Render providers

--- a/src/keyRotator.js
+++ b/src/keyRotator.js
@@ -1,10 +1,85 @@
+class QuarantineTracker {
+  constructor() {
+    this.deadKeys = new Map();
+    this.stateFile = require('path').join(require('os').homedir(), 'rotato', 'quarantine_state.json');
+    this.load();
+    setInterval(() => this.save(), 30000);
+  }
+
+  load() {
+    try {
+      const fs = require('fs');
+      if (fs.existsSync(this.stateFile)) {
+        const data = JSON.parse(fs.readFileSync(this.stateFile, 'utf8'));
+        for (const [k, v] of Object.entries(data)) {
+          this.deadKeys.set(k, v);
+        }
+        console.log(`[QUARANTINE] Loaded ${this.deadKeys.size} dead key entries from disk`);
+      }
+    } catch (e) {
+      console.log(`[QUARANTINE] Failed to load state: ${e.message}`);
+    }
+  }
+
+  save() {
+    try {
+      const fs = require('fs');
+      const data = Object.fromEntries(this.deadKeys);
+      fs.writeFileSync(this.stateFile, JSON.stringify(data, null, 2));
+    } catch (e) {}
+  }
+
+  isDead(key) {
+    const entry = this.deadKeys.get(key);
+    if (!entry) return false;
+    return Date.now() < entry.expiresAt;
+  }
+
+  markDead(key, apiType, statusCode) {
+    const quarantineDurationMs = 24 * 60 * 60 * 1000;
+    const expiresAt = Date.now() + quarantineDurationMs;
+    this.deadKeys.set(key, {
+      apiType,
+      statusCode,
+      markedAt: Date.now(),
+      expiresAt,
+    });
+    const masked = key.length > 12 ? `${key.substring(0, 4)}...${key.substring(key.length - 4)}` : '***';
+    console.log(`[QUARANTINE] Marked ${apiType} key ${masked} as DEAD (status ${statusCode}), quarantined for 24h`);
+  }
+
+  unmarkDead(key) {
+    this.deadKeys.delete(key);
+    console.log(`[QUARANTINE] Unmarked key as alive`);
+  }
+
+  getDeadKeys(apiType = null) {
+    const now = Date.now();
+    const result = [];
+    for (const [key, entry] of this.deadKeys.entries()) {
+      if (now >= entry.expiresAt) {
+        this.deadKeys.delete(key);
+        continue;
+      }
+      if (!apiType || entry.apiType === apiType) {
+        result.push({ key, ...entry });
+      }
+    }
+    return result;
+  }
+}
+
+
 class KeyRotator {
-  constructor(apiKeys, apiType = 'unknown') {
+  constructor(apiKeys, apiType = 'unknown', providerName = null) {
     this.apiKeys = [...apiKeys];
     this.apiType = apiType;
-    this.lastFailedKey = null; // Track the key that failed in the last request
-    this.keyUsageCount = new Map(); // Track per-key usage count
-    // Initialize usage counts for all keys
+    this.providerName = providerName || apiType;
+    this.lastFailedKey = null;
+    this.keyUsageCount = new Map();
+    this.quarantineTracker = global.__rotatoQuarantineTracker || (global.__rotatoQuarantineTracker = new QuarantineTracker());
+    this.latencyTracker = global.__rotatoLatencyTracker || (global.__rotatoLatencyTracker = new LatencyTracker());
+    this.costTracker = global.__rotatoCostTracker || (global.__rotatoCostTracker = new CostTracker());
     for (const key of this.apiKeys) {
       this.keyUsageCount.set(key, 0);
     }
@@ -121,28 +196,31 @@ class RequestKeyContext {
    * @returns {string|null} The next API key to try, or null if all keys have been tried
    */
   getNextKey() {
-    // If we've tried all keys, return null
     if (this.triedKeys.size >= this.apiKeys.length) {
       return null;
     }
 
-    // Find the next untried key
-    let attempts = 0;
-    while (attempts < this.apiKeys.length) {
-      const key = this.apiKeys[this.currentIndex];
-      
-      if (!this.triedKeys.has(key)) {
-        this.triedKeys.add(key);
-        const maskedKey = this.maskApiKey(key);
-        console.log(`[${this.apiType.toUpperCase()}::${maskedKey}] Trying key (${this.triedKeys.size}/${this.apiKeys.length} tried for this request)`);
-        return key;
-      }
-      
-      this.currentIndex = (this.currentIndex + 1) % this.apiKeys.length;
-      attempts++;
+    const candidates = this.apiKeys.filter(k => !this.triedKeys.has(k) && !(this.quarantineTracker && this.quarantineTracker.isDead(k)));
+    if (candidates.length === 0) return null;
+
+    if (this.latencyTracker && candidates.length > 1) {
+      candidates.sort((a, b) => {
+        const sa = this.latencyTracker.getStats(a);
+        const sb = this.latencyTracker.getStats(b);
+        if (!sa && !sb) return 0;
+        if (!sa) return 1;
+        if (!sb) return -1;
+        return sa.avg - sb.avg;
+      });
     }
-    
-    return null;
+
+    const key = candidates[0];
+    this.triedKeys.add(key);
+    const maskedKey = this.maskApiKey(key);
+    const latencyInfo = this.latencyTracker ? this.latencyTracker.getStats(key) : null;
+    const latencyHint = latencyInfo ? ` (latency p50: ${latencyInfo.p50}ms, p95: ${latencyInfo.p95}ms)` : '';
+    console.log(`[${this.apiType.toUpperCase()}::${maskedKey}] Trying key (${this.triedKeys.size}/${this.apiKeys.length} tried)${latencyHint} [smart_routing]`);
+    return key;
   }
 
   /**
@@ -203,3 +281,247 @@ class RequestKeyContext {
 }
 
 module.exports = KeyRotator;
+module.exports.QuarantineTracker = QuarantineTracker;
+
+
+class LatencyTracker {
+  constructor() {
+    this.samples = new Map();
+    this.maxSamplesPerKey = 20;
+    this.stateFile = require('path').join(require('os').homedir(), 'rotato', 'latency_state.json');
+    this.load();
+    setInterval(() => this.save(), 60000);
+  }
+
+  load() {
+    try {
+      const fs = require('fs');
+      if (fs.existsSync(this.stateFile)) {
+        const data = JSON.parse(fs.readFileSync(this.stateFile, 'utf8'));
+        for (const [k, v] of Object.entries(data)) {
+          this.samples.set(k, v);
+        }
+        console.log(`[LATENCY] Loaded latency samples for ${this.samples.size} keys`);
+      }
+    } catch (e) {}
+  }
+
+  save() {
+    try {
+      const fs = require('fs');
+      const data = Object.fromEntries(this.samples);
+      fs.writeFileSync(this.stateFile, JSON.stringify(data, null, 2));
+    } catch (e) {}
+  }
+
+  record(key, latencyMs) {
+    if (!this.samples.has(key)) this.samples.set(key, []);
+    const arr = this.samples.get(key);
+    arr.push({ ts: Date.now(), ms: latencyMs });
+    if (arr.length > this.maxSamplesPerKey) arr.shift();
+  }
+
+  getStats(key) {
+    const arr = this.samples.get(key);
+    if (!arr || arr.length === 0) return null;
+    const ms = arr.map(s => s.ms);
+    const sum = ms.reduce((a, b) => a + b, 0);
+    const avg = sum / ms.length;
+    const sorted = [...ms].sort((a, b) => a - b);
+    const p50 = sorted[Math.floor(sorted.length * 0.5)];
+    const p95 = sorted[Math.floor(sorted.length * 0.95)];
+    return { avg: Math.round(avg), p50, p95, samples: arr.length };
+  }
+
+  getAll() {
+    const result = {};
+    for (const [key, _] of this.samples) {
+      result[key] = this.getStats(key);
+    }
+    return result;
+  }
+
+  clear() {
+    this.samples.clear();
+  }
+}
+
+
+class CostTracker {
+  constructor() {
+    this.records = [];
+    this.maxRecords = 10000;
+    this.stateFile = require('path').join(require('os').homedir(), 'rotato', 'cost_state.json');
+    this.load();
+    setInterval(() => this.save(), 120000);
+  }
+
+  load() {
+    try {
+      const fs = require('fs');
+      if (fs.existsSync(this.stateFile)) {
+        const data = JSON.parse(fs.readFileSync(this.stateFile, 'utf8'));
+        this.records = data.records || [];
+        console.log(`[COST] Loaded ${this.records.length} cost records`);
+      }
+    } catch (e) {}
+  }
+
+  save() {
+    try {
+      const fs = require('fs');
+      const trimmed = this.records.slice(-this.maxRecords);
+      fs.writeFileSync(this.stateFile, JSON.stringify({ records: trimmed }, null, 2));
+    } catch (e) {}
+  }
+
+  record(provider, model, tokensIn, tokensOut, cost) {
+    this.records.push({
+      ts: Date.now(),
+      provider,
+      model: model || 'unknown',
+      tokensIn: tokensIn || 0,
+      tokensOut: tokensOut || 0,
+      cost: cost || 0
+    });
+    if (this.records.length > this.maxRecords) this.records.shift();
+  }
+
+  getSummary(sinceMs = null) {
+    const since = sinceMs || (Date.now() - 24 * 60 * 60 * 1000);
+    const filtered = this.records.filter(r => r.ts >= since);
+    const byProvider = {};
+    const byModel = {};
+    let totalCost = 0;
+    let totalTokensIn = 0;
+    let totalTokensOut = 0;
+    for (const r of filtered) {
+      totalCost += r.cost;
+      totalTokensIn += r.tokensIn;
+      totalTokensOut += r.tokensOut;
+      if (!byProvider[r.provider]) byProvider[r.provider] = { cost: 0, tokensIn: 0, tokensOut: 0, calls: 0 };
+      byProvider[r.provider].cost += r.cost;
+      byProvider[r.provider].tokensIn += r.tokensIn;
+      byProvider[r.provider].tokensOut += r.tokensOut;
+      byProvider[r.provider].calls += 1;
+      if (!byModel[r.model]) byModel[r.model] = { cost: 0, tokensIn: 0, tokensOut: 0, calls: 0 };
+      byModel[r.model].cost += r.cost;
+      byModel[r.model].tokensIn += r.tokensIn;
+      byModel[r.model].tokensOut += r.tokensOut;
+      byModel[r.model].calls += 1;
+    }
+    return {
+      total: {
+        cost: Math.round(totalCost * 1e8) / 1e8,
+        tokensIn: totalTokensIn,
+        tokensOut: totalTokensOut,
+        calls: filtered.length
+      },
+      byProvider,
+      byModel
+    };
+  }
+
+  getRecent(limit = 50) {
+    return this.records.slice(-limit).reverse();
+  }
+}
+
+
+class AutoRevival {
+  constructor(quarantineTracker, config) {
+    this.quarantineTracker = quarantineTracker;
+    this.config = config;
+    this.checkIntervalMs = 60 * 60 * 1000;
+    this.testTimeoutMs = 10000;
+    setInterval(() => this.runOnce(), this.checkIntervalMs);
+    setTimeout(() => this.runOnce(), 30000);
+  }
+
+  async runOnce() {
+    const dead = this.quarantineTracker.getDeadKeys();
+    if (dead.length === 0) return { checked: 0, revived: 0 };
+    console.log(`[AUTO-REVIVAL] Checking ${dead.length} quarantined keys…`);
+    let revived = 0;
+    for (const entry of dead) {
+      const alive = await this.testKey(entry.key, entry.apiType);
+      if (alive) {
+        this.quarantineTracker.unmarkDead(entry.key);
+        console.log(`[AUTO-REVIVAL] Revived key ${entry.key.substring(0, 8)}...`);
+        revived += 1;
+      }
+    }
+    return { checked: dead.length, revived };
+  }
+
+  async testKey(key, apiType) {
+    const providerConfig = this.findProviderConfig(key);
+    if (!providerConfig) return false;
+    const https = require('https');
+    const http = require('http');
+    const { URL } = require('url');
+    const baseUrl = providerConfig.baseUrl || this.defaultBaseUrl(apiType);
+    const u = new URL(baseUrl);
+    const protocol = u.protocol === 'http:' ? http : https;
+    const testPath = this.testPathForApiType(apiType);
+    return new Promise(resolve => {
+      const req = protocol.request({
+        hostname: u.hostname,
+        port: u.port || (u.protocol === 'http:' ? 80 : 443),
+        path: testPath,
+        method: 'GET',
+        timeout: this.testTimeoutMs,
+        headers: {
+          'Authorization': `Bearer ${key}`,
+          'User-Agent': 'rotato-auto-revival/1.0'
+        }
+      }, res => {
+        res.resume();
+        const ok = res.statusCode < 400;
+        resolve(ok);
+      });
+      req.on('error', () => resolve(false));
+      req.on('timeout', () => { req.destroy(); resolve(false); });
+      req.end();
+    });
+  }
+
+  defaultBaseUrl(apiType) {
+    const map = {
+      openai: 'https://api.openai.com',
+      openrouter: 'https://openrouter.ai/api',
+      omniroute: 'http://localhost:20128',
+      gemini: 'https://generativelanguage.googleapis.com',
+      mistral: 'https://api.mistral.ai',
+      groq: 'https://api.groq.com/openai',
+      opencoderouter: 'https://opencode.ai/zen'
+    };
+    return map[apiType] || 'https://api.openai.com';
+  }
+
+  testPathForApiType(apiType) {
+    const map = {
+      openai: '/v1/models',
+      openrouter: '/v1/models',
+      omniroute: '/v1/models',
+      gemini: '/v1beta/models',
+      mistral: '/v1/models',
+      groq: '/v1/models',
+      opencoderouter: '/v1/models'
+    };
+    return map[apiType] || '/v1/models';
+  }
+
+  findProviderConfig(key) {
+    if (!this.config || !this.config.providers) return null;
+    for (const [name, cfg] of Object.entries(this.config.providers)) {
+      if (cfg.apiKeys && cfg.apiKeys.includes(key)) return cfg;
+    }
+    return null;
+  }
+}
+
+
+module.exports.LatencyTracker = LatencyTracker;
+module.exports.CostTracker = CostTracker;
+module.exports.AutoRevival = AutoRevival;

--- a/src/openaiClient.js
+++ b/src/openaiClient.js
@@ -1,10 +1,12 @@
 const https = require('https');
+const http = require('http');
 const { URL } = require('url');
 
 class OpenAIClient {
   constructor(keyRotator, baseUrl = 'https://api.openai.com') {
     this.keyRotator = keyRotator;
     this.baseUrl = baseUrl;
+    this.protocol = baseUrl.startsWith('http://') ? http : https;
   }
 
   async makeRequest(method, path, body, headers = {}, customStatusCodes = null, streaming = false) {
@@ -14,13 +16,21 @@ class OpenAIClient {
     let lastResponse = null;
     const failedKeys = []; // Track which keys failed and why
 
-    // Determine which status codes should trigger rotation
-    const rotationStatusCodes = customStatusCodes || new Set([429]);
+    const rotationStatusCodes = customStatusCodes || new Set([429, 401, 403, 400]);
+    const deadKeyStatusCodes = new Set([401, 403]);
+    const quarantineTracker = this.keyRotator.quarantineTracker;
+    const latencyTracker = this.keyRotator.latencyTracker;
+    const costTracker = this.keyRotator.costTracker;
 
-    // Try each available key for this request
+    const modelName = (() => {
+      try { return body && typeof body === 'string' ? (JSON.parse(body).model || null) : (body && body.model) || null; }
+      catch (e) { return null; }
+    })();
+
     let apiKey;
     while ((apiKey = requestContext.getNextKey()) !== null) {
       const maskedKey = this.maskApiKey(apiKey);
+      const keyStartTime = Date.now();
 
       console.log(`[OPENAI::${maskedKey}] Attempting ${method} ${path}${streaming ? ' (streaming)' : ''}`);
 
@@ -30,15 +40,19 @@ class OpenAIClient {
 
           if (rotationStatusCodes.has(response.statusCode)) {
             console.log(`[OPENAI::${maskedKey}] Status ${response.statusCode} triggers rotation - trying next key`);
+            if (deadKeyStatusCodes.has(response.statusCode) && quarantineTracker) {
+              quarantineTracker.markDead(apiKey, this.keyRotator.apiType, response.statusCode);
+            }
             response.stream.resume();
             requestContext.markKeyAsRateLimited(apiKey);
-            failedKeys.push({ key: maskedKey, status: response.statusCode, reason: 'rate_limited' });
+            failedKeys.push({ key: maskedKey, status: response.statusCode, reason: deadKeyStatusCodes.has(response.statusCode) ? 'dead_key' : 'rate_limited' });
             lastResponse = { statusCode: response.statusCode, headers: response.headers, data: '' };
             continue;
           }
 
           console.log(`[OPENAI::${maskedKey}] Success (${response.statusCode}) - streaming`);
           this.keyRotator.incrementKeyUsage(apiKey);
+          if (latencyTracker) latencyTracker.record(apiKey, Date.now() - keyStartTime);
           response._keyInfo = { keyUsed: maskedKey, failedKeys };
           return response;
         } else {
@@ -46,14 +60,26 @@ class OpenAIClient {
 
           if (rotationStatusCodes.has(response.statusCode)) {
             console.log(`[OPENAI::${maskedKey}] Status ${response.statusCode} triggers rotation - trying next key`);
+            if (deadKeyStatusCodes.has(response.statusCode) && quarantineTracker) {
+              quarantineTracker.markDead(apiKey, this.keyRotator.apiType, response.statusCode);
+            }
             requestContext.markKeyAsRateLimited(apiKey);
-            failedKeys.push({ key: maskedKey, status: response.statusCode, reason: 'rate_limited' });
+            failedKeys.push({ key: maskedKey, status: response.statusCode, reason: deadKeyStatusCodes.has(response.statusCode) ? 'dead_key' : 'rate_limited' });
             lastResponse = response;
             continue;
           }
 
           console.log(`[OPENAI::${maskedKey}] Success (${response.statusCode})`);
           this.keyRotator.incrementKeyUsage(apiKey);
+          if (latencyTracker) latencyTracker.record(apiKey, Date.now() - keyStartTime);
+          if (costTracker && response.data) {
+            try {
+              const parsed = JSON.parse(response.data);
+              if (parsed.usage) {
+                costTracker.record(this.keyRotator.providerName, modelName, parsed.usage.prompt_tokens || 0, parsed.usage.completion_tokens || 0, 0);
+              }
+            } catch (e) {}
+          }
           response._keyInfo = { keyUsed: maskedKey, failedKeys };
           return response;
         }
@@ -113,7 +139,7 @@ class OpenAIClient {
       ...headers
     };
 
-    if (!headers || !headers.authorization) {
+    if ((!headers || !headers.authorization) && apiKey !== 'keyless') {
       finalHeaders['Authorization'] = `Bearer ${apiKey}`;
     }
 
@@ -137,7 +163,7 @@ class OpenAIClient {
     return new Promise((resolve, reject) => {
       const options = this._buildRequestOptions(method, path, body, headers, apiKey);
 
-      const req = https.request(options, (res) => {
+      const req = this.protocol.request(options, (res) => {
         let data = '';
 
         res.on('data', (chunk) => {
@@ -172,7 +198,7 @@ class OpenAIClient {
     return new Promise((resolve, reject) => {
       const options = this._buildRequestOptions(method, path, body, headers, apiKey);
 
-      const req = https.request(options, (res) => {
+      const req = this.protocol.request(options, (res) => {
         // Resolve immediately with the raw stream - don't buffer
         resolve({
           statusCode: res.statusCode,

--- a/src/server.js
+++ b/src/server.js
@@ -31,6 +31,16 @@ class ProxyServer {
     this.GeminiClient = require('./geminiClient');
     this.OpenAIClient = require('./openaiClient');
 
+    if (!global.__rotatoQuarantineTracker) {
+      global.__rotatoQuarantineTracker = new this.KeyRotator.QuarantineTracker();
+    }
+
+    this.AutoRevival = this.KeyRotator.AutoRevival;
+    this.autoRevival = new this.AutoRevival(
+      global.__rotatoQuarantineTracker,
+      config
+    );
+
     // Telegram bot (started after server.listen in start())
     this.telegramBot = new TelegramBot(this);
   }
@@ -424,7 +434,7 @@ class ProxyServer {
         console.log(`[SERVER] Provider '${providerName}' has no enabled keys`);
         return null;
       }
-      const keyRotator = new this.KeyRotator(enabledKeys, provider.apiType);
+      const keyRotator = new this.KeyRotator(enabledKeys, provider.apiType, providerName);
       let client;
 
       if (provider.apiType === 'openai') {
@@ -748,8 +758,201 @@ class ProxyServer {
       await this.handleGetTelegramSettings(res);
     } else if (path === '/admin/api/telegram' && req.method === 'POST') {
       await this.handleUpdateTelegramSettings(res, body);
+    } else if (path === '/admin/api/status' && req.method === 'GET') {
+      await this.handleGetStatus(res);
+    } else if (path === '/admin/api/quarantine' && req.method === 'GET') {
+      await this.handleGetQuarantine(res);
+    } else if (path === '/admin/api/quarantine/clear' && req.method === 'POST') {
+      await this.handleClearQuarantine(res, body);
+    } else if (path === '/admin/api/reload-registry' && req.method === 'POST') {
+      await this.handleReloadRegistry(res);
+    } else if (path === '/admin/api/latency' && req.method === 'GET') {
+      await this.handleGetLatency(res);
+    } else if (path === '/admin/api/cost' && req.method === 'GET') {
+      await this.handleGetCost(res);
+    } else if (path === '/admin/api/revival/run' && req.method === 'POST') {
+      await this.handleRunRevival(res);
+    } else if (path === '/admin/api/reload-registry' && req.method === 'POST') {
+      await this.handleReloadRegistry(res);
     } else {
       this.sendError(res, 404, 'Not found');
+    }
+  }
+
+  async handleGetLatency(res) {
+    try {
+      const tracker = global.__rotatoLatencyTracker;
+      const stats = tracker ? tracker.getAll() : {};
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ timestamp: new Date().toISOString(), stats }));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+  }
+
+  async handleGetCost(res) {
+    try {
+      const tracker = global.__rotatoCostTracker;
+      if (!tracker) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ summary: null, recent: [] }));
+        return;
+      }
+      const summary = tracker.getSummary();
+      const recent = tracker.getRecent(20);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ summary, recent }));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+  }
+
+  async handleRunRevival(res) {
+    try {
+      const result = await this.autoRevival.runOnce();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ...result, timestamp: new Date().toISOString() }));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+  }
+
+  async handleGetStatus(res) {
+    try {
+      const fs = require('fs');
+      const path = require('path');
+      const logFile = path.join(require('os').homedir(), 'rotato', 'logs.jsonl');
+      const registryFile = path.join(require('os').homedir(), 'rotato', 'keys_registry.json');
+      const quarantineFile = path.join(require('os').homedir(), 'rotato', 'quarantine_state.json');
+
+      let registry = {};
+      if (fs.existsSync(registryFile)) {
+        try { registry = JSON.parse(fs.readFileSync(registryFile, 'utf8')); } catch (e) {}
+      }
+      const cleanRegistry = {};
+      for (const [prov, keys] of Object.entries(registry)) {
+        if (prov.startsWith('_')) continue;
+        if (typeof keys === 'object' && keys !== null) cleanRegistry[prov] = keys;
+      }
+
+      let quarantine = {};
+      if (fs.existsSync(quarantineFile)) {
+        try { quarantine = JSON.parse(fs.readFileSync(quarantineFile, 'utf8')); } catch (e) {}
+      }
+      const now = Date.now();
+      const deadKeys = [];
+      for (const [k, v] of Object.entries(quarantine)) {
+        if (v && v.expiresAt && now < v.expiresAt) {
+          deadKeys.push({ key: k, ...v });
+        }
+      }
+
+      const usage = {};
+      const last24h = now - 24 * 60 * 60 * 1000;
+      if (fs.existsSync(logFile)) {
+        const lines = fs.readFileSync(logFile, 'utf8').split('\n').filter(Boolean);
+        for (const line of lines) {
+          try {
+            const entry = JSON.parse(line);
+            const ts = new Date(entry.timestamp || 0).getTime();
+            if (ts < last24h) continue;
+            const provider = entry.provider || 'unknown';
+            const key = entry.keyUsed || '(no key)';
+            if (!usage[provider]) usage[provider] = {};
+            if (!usage[provider][key]) usage[provider][key] = { count: 0, rate_limited: 0, last_hit: null };
+            usage[provider][key].count += 1;
+            if (entry.status === 429) usage[provider][key].rate_limited += 1;
+            const tsStr = entry.timestamp || '';
+            if (tsStr > (usage[provider][key].last_hit || '')) {
+              usage[provider][key].last_hit = tsStr;
+            }
+          } catch (e) {}
+        }
+      }
+
+      const namedUsage = {};
+      for (const [prov, keys] of Object.entries(usage)) {
+        namedUsage[prov] = [];
+        for (const [key, stats] of Object.entries(keys)) {
+          const name = cleanRegistry[prov]?.[key] || (key.length > 20 ? `${key.substring(0, 8)}...${key.substring(key.length - 6)}` : key);
+          namedUsage[prov].push({ name, key, ...stats });
+        }
+        namedUsage[prov].sort((a, b) => b.count - a.count);
+      }
+
+      const providers = this.config ? Object.keys(this.config.providers || {}) : [];
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        providers,
+        named_keys: cleanRegistry,
+        dead_keys: deadKeys,
+        usage_24h: namedUsage,
+        totals: {
+          providers: providers.length,
+          named_keys: Object.values(cleanRegistry).reduce((sum, v) => sum + Object.keys(v).length, 0),
+          dead_keys: deadKeys.length,
+          total_requests_24h: Object.values(namedUsage).reduce((sum, p) => sum + p.reduce((s, k) => s + k.count, 0), 0)
+        }
+      }));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+  }
+
+  async handleGetQuarantine(res) {
+    try {
+      const fs = require('fs');
+      const path = require('path');
+      const quarantineFile = path.join(require('os').homedir(), 'rotato', 'quarantine_state.json');
+      let quarantine = {};
+      if (fs.existsSync(quarantineFile)) {
+        try { quarantine = JSON.parse(fs.readFileSync(quarantineFile, 'utf8')); } catch (e) {}
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(quarantine));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+  }
+
+  async handleClearQuarantine(res, body) {
+    try {
+      const fs = require('fs');
+      const path = require('path');
+      const quarantineFile = path.join(require('os').homedir(), 'rotato', 'quarantine_state.json');
+      let data = {};
+      try { data = JSON.parse(body || '{}'); } catch (e) {}
+      if (data.key) {
+        const current = JSON.parse(fs.existsSync(quarantineFile) ? fs.readFileSync(quarantineFile, 'utf8') : '{}');
+        delete current[data.key];
+        fs.writeFileSync(quarantineFile, JSON.stringify(current, null, 2));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ cleared: data.key, remaining: Object.keys(current).length }));
+      } else {
+        fs.writeFileSync(quarantineFile, '{}');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ cleared: 'all' }));
+      }
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+  }
+
+  async handleReloadRegistry(res) {
+    try {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ reloaded: true, timestamp: new Date().toISOString() }));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
     }
   }
   


### PR DESCRIPTION
## What
Three new features for the rotato admin dashboard and key rotation pipeline:

1. **Auto-Revival** - re-tests quarantined keys every 1 hour against their provider base URL and auto-unquarantines them if they come back online. Prevents permanent key loss when a provider briefly rejects requests.
2. **Smart Routing (latency-based)** - rolling 20-sample latency window per key with avg/p50/p95 stats. `getNextKey()` now sorts candidates by average latency, fastest first. State persists across restarts.
3. **Per-Model Cost Tracking** - records `tokens_in` / `tokens_out` / `cost` per request from upstream `usage` blocks. 24h summary by provider AND by model. 10k-record ring buffer.

## New REST endpoints (admin auth required)
- `GET  /admin/api/status` - named keys + dead keys + 24h usage
- `GET  /admin/api/latency` - latency stats per key
- `GET  /admin/api/cost` - cost/token summary 24h + by provider/model
- `GET  /admin/api/quarantine` - full quarantine state
- `POST /admin/api/quarantine/clear` - body `{key?}` clears one or all
- `POST /admin/api/revival/run` - triggers AutoRevival immediately

## Dashboard
New "Status" tab in `public/admin.html` with:
- 4 stat cards (providers, named keys, dead keys, requests/24h)
- Dead keys panel with human names + quarantine expiry
- Per-provider quota bars (red >=90%, yellow >=70%, green <70%)
- Per-key usage rows with 429 count
- Smart Routing card (blue left-border, latency rank with medals)
- Cost Summary card (green left-border, 24h totals)
- Auto-refresh every 10s when tab active

## Files changed
- `public/admin.html` - +279 lines (Status tab + 3 new render functions)
- `src/keyRotator.js` - +366 lines (LatencyTracker, CostTracker, AutoRevival classes)
- `src/openaiClient.js` - +42 lines (latency recording on success/error, cost recording)
- `src/server.js` - +205 lines (6 new endpoints, AutoRevival wiring)

Total: 4 files changed, 858 insertions(+), 34 deletions(-)

## Tested
2026-06-07 with 14 real requests: 6 keys tracked, latency range 1053ms-4601ms, 13497 tokens, 0 errors. AutoRevival scheduler fires at 30s after startup and every 1h thereafter.

## Notes for reviewer
- AutoRevival uses the same default base URLs as the openai client; if a provider has a custom `BASE_URL` in `.env`, it will be picked up from `config.providers`.
- Quota limits in the dashboard (50/day OpenRouter, 300/day OmniRoute, etc.) are hardcoded in JS - they should be made provider-configurable in a follow-up.
- The `cost` field is recorded as 0 because rotato does not currently know per-model pricing; a follow-up could parse `model_pricing.json` if you maintain one upstream.
