### PR TITLE
Add outbound proxy support + revamp logs and response viewer UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
 PORT=8990
 ADMIN_PASSWORD=your-secure-password
+
+# Optional outbound proxy (managed from the admin panel → Proxy tab)
+# Route upstream API requests through one or more proxies, rotated per request.
+# Supported schemes: http://, https://, socks5://  (with optional user:pass@)
+# PROXY_ENABLED=true
+# PROXY_URLS=http://user:pass@host:port,socks5://host:1080

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function main() {
     
     if (config.hasGeminiKeys()) {
       const geminiKeyRotator = new KeyRotator(config.getGeminiApiKeys(), 'gemini');
-      geminiClient = new GeminiClient(geminiKeyRotator, config.getGeminiBaseUrl());
+      geminiClient = new GeminiClient(geminiKeyRotator, config.getGeminiBaseUrl(), config.getProxyManager());
       console.log('[INIT] Legacy Gemini client initialized');
     } else if (config.hasAdminPassword()) {
       console.log('[INIT] No legacy Gemini keys found - can be configured via admin panel');
@@ -22,7 +22,7 @@ function main() {
     
     if (config.hasOpenaiKeys()) {
       const openaiKeyRotator = new KeyRotator(config.getOpenaiApiKeys(), 'openai');
-      openaiClient = new OpenAIClient(openaiKeyRotator, config.getOpenaiBaseUrl());
+      openaiClient = new OpenAIClient(openaiKeyRotator, config.getOpenaiBaseUrl(), config.getProxyManager());
       console.log('[INIT] Legacy OpenAI client initialized');
     } else if (config.hasAdminPassword()) {
       console.log('[INIT] No legacy OpenAI keys found - can be configured via admin panel');

--- a/public/admin.html
+++ b/public/admin.html
@@ -455,13 +455,6 @@
                         </div>
                     </div>
                     <div class="flex items-center space-x-3">
-                        <!-- Settings Button -->
-                        <button onclick="openSettingsModal()" class="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors" title="Settings">
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                            </svg>
-                        </button>
                         <!-- Dark Mode Toggle -->
                         <div class="flex items-center space-x-1.5">
                             <svg class="w-3 h-3 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -510,6 +503,27 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                             </svg>
                             <span class="text-sm">API Logs</span>
+                        </button>
+                        <button
+                            onclick="showTab('proxy')"
+                            class="tab-btn py-3 px-2 border-b-2 border-transparent text-muted-foreground hover:text-foreground hover:border-border transition-colors flex items-center space-x-2"
+                            data-tab="proxy"
+                        >
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12h18M3 12a9 9 0 019-9m-9 9a9 9 0 009 9m0-18a9 9 0 019 9m-9-9c2.5 2.5 2.5 15.5 0 18m0-18c-2.5 2.5-2.5 15.5 0 18" />
+                            </svg>
+                            <span class="text-sm">Proxy</span>
+                        </button>
+                        <button
+                            onclick="showTab('settings')"
+                            class="tab-btn py-3 px-2 border-b-2 border-transparent text-muted-foreground hover:text-foreground hover:border-border transition-colors flex items-center space-x-2"
+                            data-tab="settings"
+                        >
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                            </svg>
+                            <span class="text-sm">Settings</span>
                         </button>
                     </nav>
                     
@@ -649,26 +663,196 @@
             <div id="logs" class="tab-content hidden">
                 <div class="section-header">
                     <h2 class="text-lg font-semibold text-foreground">API Request Logs</h2>
-                    <p class="text-muted-foreground text-xs mt-1">Monitor OpenAI and Gemini API requests and responses</p>
+                    <p class="text-muted-foreground text-xs mt-1">Monitor OpenAI and Gemini API requests, keys, and the proxy each request used</p>
+                </div>
+
+                <div class="section">
+                    <!-- Toolbar: search + filters + actions -->
+                    <div class="flex flex-wrap items-center gap-2 mb-3">
+                        <div class="relative flex-1 min-w-[200px]">
+                            <svg class="w-3.5 h-3.5 absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                            </svg>
+                            <input id="logSearch" type="text" oninput="renderLogs()" placeholder="Search endpoint, key, proxy, status…" class="input-field w-full pl-8 pr-2 py-1.5 text-xs rounded">
+                        </div>
+                        <select id="logProviderFilter" onchange="renderLogs()" class="input-field px-2 py-1.5 text-xs rounded">
+                            <option value="">All providers</option>
+                        </select>
+                        <select id="logStatusFilter" onchange="renderLogs()" class="input-field px-2 py-1.5 text-xs rounded">
+                            <option value="">All statuses</option>
+                            <option value="success">✓ Success (2xx)</option>
+                            <option value="redirect">Redirect (3xx)</option>
+                            <option value="clienterror">Client error (4xx)</option>
+                            <option value="servererror">Server error (5xx)</option>
+                        </select>
+                        <select id="logProxyFilter" onchange="renderLogs()" class="input-field px-2 py-1.5 text-xs rounded">
+                            <option value="">Any routing</option>
+                            <option value="proxy">Via proxy</option>
+                            <option value="direct">Direct</option>
+                        </select>
+                        <label class="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none px-1" title="Auto-refresh every 5s">
+                            <input type="checkbox" id="logAutoRefresh" onchange="toggleLogAutoRefresh()" class="w-3.5 h-3.5"> Live
+                        </label>
+                        <button onclick="handleRefreshLogs(this)" class="btn btn-secondary px-3 py-1.5 text-xs font-medium flex items-center gap-1.5" title="Refresh logs">
+                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
+                            </svg>
+                            Reload
+                        </button>
+                    </div>
+
+                    <div class="flex items-center justify-between mb-2 text-xs text-muted-foreground">
+                        <span id="logCount">—</span>
+                        <span>Last 100 entries in memory • lost on restart</span>
+                    </div>
+
+                    <!-- Table -->
+                    <div class="border border-border rounded-md overflow-hidden">
+                        <div class="overflow-x-auto max-h-[70vh] overflow-y-auto">
+                            <table class="w-full text-xs border-collapse">
+                                <thead class="bg-muted sticky top-0 z-10">
+                                    <tr class="text-left text-muted-foreground">
+                                        <th class="font-medium px-2.5 py-2 whitespace-nowrap">Time</th>
+                                        <th class="font-medium px-2.5 py-2">Request</th>
+                                        <th class="font-medium px-2.5 py-2 whitespace-nowrap">Provider</th>
+                                        <th class="font-medium px-2.5 py-2 whitespace-nowrap">Status</th>
+                                        <th class="font-medium px-2.5 py-2 whitespace-nowrap text-right">Latency</th>
+                                        <th class="font-medium px-2.5 py-2 whitespace-nowrap">Key</th>
+                                        <th class="font-medium px-2.5 py-2 whitespace-nowrap">Proxy</th>
+                                        <th class="font-medium px-2.5 py-2"></th>
+                                    </tr>
+                                </thead>
+                                <tbody id="logsTableBody" class="divide-y divide-border"></tbody>
+                            </table>
+                        </div>
+                        <div id="logsEmpty" class="hidden p-8 text-center text-xs text-muted-foreground">No logs available yet.</div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Proxy Tab -->
+            <div id="proxy" class="tab-content hidden">
+                <div class="section-header">
+                    <h2 class="text-lg font-semibold text-foreground">Outbound Proxy</h2>
+                    <p class="text-muted-foreground text-xs mt-1">Route all upstream API requests through a proxy. If an IP gets blocked, change the proxy here and save — no restart needed.</p>
                 </div>
 
                 <div class="space-y-4">
-
-                    <!-- Logs Display -->
+                    <!-- Enable + Proxy List -->
                     <div class="section">
                         <div class="flex items-center justify-between mb-3">
-                            <h3 class="text-sm font-medium text-foreground">Recent API Requests</h3>
-                            <button onclick="handleRefreshLogs(this)" class="btn btn-secondary px-3 py-1.5 text-xs font-medium flex items-center gap-1.5" title="Refresh logs">
-                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
-                                </svg>
-                                Reload
-                            </button>
+                            <h3 class="text-sm font-medium text-foreground">Proxy Configuration</h3>
+                            <label class="flex items-center gap-2 cursor-pointer select-none">
+                                <input type="checkbox" id="proxyEnabled" class="w-4 h-4">
+                                <span class="text-sm text-foreground">Enable proxy routing</span>
+                            </label>
                         </div>
-                        <p class="text-xs text-muted-foreground mb-3">Last 100 entries kept in memory • Lost on server restart</p>
-                        <div class="bg-gray-900 border border-border rounded">
-                            <div id="logsContainer" class="text-green-400 p-3 font-mono text-xs h-80 overflow-y-auto whitespace-pre-wrap"></div>
+
+                        <label class="block text-xs font-medium text-muted-foreground mb-2">Proxy URLs — one per line (rotated round-robin, one per request)</label>
+                        <textarea
+                            id="proxyUrls"
+                            rows="5"
+                            class="input-field w-full px-2 py-1.5 text-xs rounded transition-colors font-mono"
+                            placeholder="http://user:pass@host:port&#10;https://host:port&#10;socks5://user:pass@host:1080"
+                        ></textarea>
+                        <p class="text-muted-foreground text-xs mt-1">Supported: <code>http://</code>, <code>https://</code>, <code>socks5://</code> — with optional <code>user:pass@</code>. A bare <code>host:port</code> is treated as HTTP.</p>
+
+                        <div class="flex items-center space-x-2 mt-3">
+                            <button onclick="saveProxySettings(this)" class="btn btn-primary px-3 py-1.5 text-xs font-medium">Save Proxy Settings</button>
+                            <button onclick="loadProxySettings()" class="btn btn-secondary px-3 py-1.5 text-xs font-medium">Reload</button>
                         </div>
+                    </div>
+
+                    <!-- Configured proxies + per-proxy test -->
+                    <div class="section">
+                        <div class="flex items-center justify-between mb-3">
+                            <h3 class="text-sm font-medium text-foreground">Saved Proxies</h3>
+                            <button onclick="testAllProxies(this)" class="btn btn-secondary px-3 py-1.5 text-xs font-medium">Test All (show outbound IP)</button>
+                        </div>
+                        <div id="proxyListContainer" class="space-y-2"></div>
+                        <p id="proxyListEmpty" class="text-xs text-muted-foreground">No proxies saved yet.</p>
+                    </div>
+                </div>
+
+                <div id="proxySuccess" class="hidden bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-md mt-4"></div>
+                <div id="proxyError" class="hidden bg-destructive/10 border border-destructive/20 text-destructive px-4 py-3 rounded-md mt-4"></div>
+            </div>
+
+            <!-- Settings Tab -->
+            <div id="settings" class="tab-content hidden">
+                <div class="section-header">
+                    <h2 class="text-lg font-semibold text-foreground">Settings</h2>
+                    <p class="text-muted-foreground text-xs mt-1">Key rotation behavior and Telegram bot configuration</p>
+                </div>
+
+                <div class="space-y-4">
+                    <!-- Key Rotation Section -->
+                    <div class="section">
+                        <h3 class="text-sm font-medium text-foreground mb-3 flex items-center gap-2">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                            </svg>
+                            Key Rotation
+                        </h3>
+                        <div class="space-y-3">
+                            <div>
+                                <label class="block text-xs font-medium text-muted-foreground mb-1">Default Status Codes to Rotate <span class="font-normal">(comma-separated)</span></label>
+                                <input type="text" id="defaultStatusCodes" class="input-field w-full px-3 py-2 rounded-md text-sm" placeholder="429" value="429">
+                                <p class="text-xs text-muted-foreground mt-1">When the API returns any of these status codes, the proxy rotates to the next API key. Reflected in all generated cURL commands.</p>
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-muted-foreground mb-1">Keep-Alive Interval <span class="font-normal">(minutes, 0 to disable)</span></label>
+                                <input type="number" id="keepAliveMinutes" class="input-field w-full px-3 py-2 rounded-md text-sm" placeholder="10" value="10" min="0" step="1">
+                                <p class="text-xs text-muted-foreground mt-1">Pings the server periodically to prevent hosting platforms from sleeping it due to inactivity. Set to 0 to disable.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Telegram Bot Section -->
+                    <div class="section">
+                        <h3 class="text-sm font-medium text-foreground mb-3 flex items-center gap-2">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69a.2.2 0 00-.05-.18c-.06-.05-.14-.03-.21-.02-.09.02-1.49.95-4.22 2.79-.4.27-.76.41-1.08.4-.36-.01-1.04-.2-1.55-.37-.63-.2-1.12-.31-1.08-.66.02-.18.27-.36.74-.55 2.92-1.27 4.86-2.11 5.83-2.51 2.78-1.16 3.35-1.36 3.73-1.36.08 0 .27.02.39.12.1.08.13.19.14.27-.01.06.01.24 0 .38z"/>
+                            </svg>
+                            Telegram Bot
+                        </h3>
+                        <div class="space-y-3">
+                            <div>
+                                <label class="block text-xs font-medium text-muted-foreground mb-1">Bot Token</label>
+                                <input type="password" id="telegramBotToken" class="input-field w-full px-3 py-2 rounded-md text-sm" placeholder="123456789:ABCdefGhIjKlMnOpQrStUvWxYz">
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-muted-foreground mb-1">Allowed User IDs <span class="font-normal">(comma-separated, leave empty to allow all)</span></label>
+                                <input type="text" id="telegramAllowedUsers" class="input-field w-full px-3 py-2 rounded-md text-sm" placeholder="123456789, 987654321">
+                            </div>
+                            <div id="telegramBotStatus" class="text-xs"></div>
+
+                            <div class="border border-border rounded-md p-3 bg-muted/30">
+                                <p class="text-xs font-medium text-foreground mb-2">How to set up:</p>
+                                <ol class="text-xs text-muted-foreground space-y-1.5 list-decimal list-inside">
+                                    <li>Open Telegram and search for <strong>@BotFather</strong></li>
+                                    <li>Send <code class="bg-muted px-1 rounded">/newbot</code> and follow the prompts</li>
+                                    <li>Copy the bot token and paste it above</li>
+                                    <li>To get your User ID, search for <strong>@userinfobot</strong> on Telegram and send it any message</li>
+                                    <li>Add your User ID to the allowed list (or leave empty to allow anyone)</li>
+                                </ol>
+                                <div class="mt-2 pt-2 border-t border-border">
+                                    <p class="text-xs font-medium text-foreground mb-1">Bot commands:</p>
+                                    <div class="text-xs text-muted-foreground space-y-0.5">
+                                        <p><code class="bg-muted px-1 rounded">/models</code> - Select provider & model</p>
+                                        <p><code class="bg-muted px-1 rounded">/clear</code> - Clear conversation history</p>
+                                        <p><code class="bg-muted px-1 rounded">/logs</code> - View recent API logs</p>
+                                        <p><code class="bg-muted px-1 rounded">/status</code> - Show current model info</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Save (persists both Key Rotation + Telegram settings) -->
+                    <div class="flex items-center space-x-2">
+                        <button onclick="saveTelegramSettings()" class="btn btn-primary px-3 py-1.5 text-xs font-medium">Save Settings</button>
+                        <button onclick="loadTelegramSettings()" class="btn btn-secondary px-3 py-1.5 text-xs font-medium">Reload</button>
                     </div>
                 </div>
             </div>
@@ -748,45 +932,47 @@
     </div>
 
     <!-- Response Viewer Dialog -->
-    <div id="responseDialog" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-[110]">
-        <div class="bg-card border border-border rounded-lg p-6 max-w-4xl w-full h-[80vh] flex flex-col shadow-xl">
-            <div class="flex items-center justify-between mb-4 flex-shrink-0">
-                <div>
-                    <h3 class="text-lg font-semibold text-foreground">API Response</h3>
-                    <p class="text-sm text-muted-foreground" id="responseInfo">Loading...</p>
+    <div id="responseDialog" class="hidden fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-[110]" onclick="if(event.target===this)closeResponseDialog()">
+        <div class="bg-card border border-border rounded-xl w-full max-w-4xl h-[85vh] flex flex-col shadow-2xl overflow-hidden">
+            <!-- Header: status + method + endpoint + meta chips -->
+            <div class="flex items-start justify-between gap-3 px-4 py-3 border-b border-border flex-shrink-0">
+                <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2 flex-wrap">
+                        <span id="rvStatusBadge" class="inline-block px-2 py-0.5 rounded-md text-xs font-semibold border">—</span>
+                        <span id="rvMethod" class="inline-block px-1.5 py-0.5 rounded bg-muted text-foreground text-xs font-medium">—</span>
+                        <span id="rvEndpoint" class="font-mono text-sm text-foreground truncate max-w-full" title=""></span>
+                    </div>
+                    <div class="flex items-center gap-1.5 flex-wrap mt-2" id="rvMeta"></div>
                 </div>
-                <button 
-                    onclick="closeResponseDialog()" 
-                    class="text-muted-foreground hover:text-foreground transition-colors p-1"
-                >
+                <button onclick="closeResponseDialog()" class="text-muted-foreground hover:text-foreground transition-colors p-1 flex-shrink-0" title="Close (Esc)">
                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                     </svg>
                 </button>
             </div>
-            
-            <!-- Tabs for Request/Response -->
-            <div class="flex space-x-4 mb-4 flex-shrink-0" id="requestResponseTabs">
-                <button 
-                    id="responseTab"
-                    onclick="switchResponseTab('response')" 
-                    class="px-4 py-2 rounded-md text-sm font-medium btn-primary"
-                >
-                    Response
-                </button>
-                <button 
-                    id="requestTab"
-                    onclick="switchResponseTab('request')" 
-                    class="px-4 py-2 rounded-md text-sm font-medium btn-secondary hidden disabled:opacity-50 disabled:cursor-not-allowed"
-                    disabled
-                >
-                    Request Body
-                </button>
+
+            <!-- Toolbar: segmented tabs + actions -->
+            <div class="flex items-center justify-between gap-2 px-4 py-2 border-b border-border flex-shrink-0 bg-muted/30">
+                <div class="inline-flex rounded-md border border-border p-0.5 bg-background" id="requestResponseTabs">
+                    <button id="responseTab" onclick="switchResponseTab('response')" class="px-3 py-1 rounded text-xs font-medium transition-colors">Response</button>
+                    <button id="requestTab" onclick="switchResponseTab('request')" class="px-3 py-1 rounded text-xs font-medium transition-colors" disabled>Request</button>
+                </div>
+                <div class="flex items-center gap-1.5">
+                    <button onclick="toggleResponseWrap()" id="rvWrapBtn" class="btn btn-secondary px-2.5 py-1 text-xs font-medium flex items-center gap-1" title="Toggle line wrapping">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h13a3 3 0 010 6h-3m0 0l2-2m-2 2l2 2M4 18h4"/></svg>
+                        Wrap
+                    </button>
+                    <button onclick="copyResponseView(this)" id="rvCopyBtn" class="btn btn-secondary px-2.5 py-1 text-xs font-medium flex items-center gap-1" title="Copy visible content">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                        Copy
+                    </button>
+                </div>
             </div>
-            
-            <div class="flex-1 min-h-0">
-                <pre id="responseContent" class="bg-gray-900 text-green-400 p-4 rounded-md text-sm h-full overflow-auto font-mono whitespace-pre-wrap border"></pre>
-                <pre id="requestContent" class="bg-gray-900 text-yellow-400 p-4 rounded-md text-sm h-full overflow-auto font-mono whitespace-pre-wrap border hidden"></pre>
+
+            <!-- Body -->
+            <div class="flex-1 min-h-0 overflow-auto" style="background:#0d1117;">
+                <pre id="responseContent" class="p-4 text-[13px] leading-relaxed font-mono whitespace-pre text-gray-200 min-w-full"></pre>
+                <pre id="requestContent" class="p-4 text-[13px] leading-relaxed font-mono whitespace-pre text-gray-200 min-w-full hidden"></pre>
             </div>
         </div>
     </div>
@@ -3303,196 +3489,323 @@ ${googApiKeyHeader}  -H "Content-Type: application/json" \\
             }
         }
         
+        // In-memory cache of the most recent logs (newest first, deduped by requestId).
+        // Filters/search re-render from this without re-fetching.
+        let _logsCache = [];
+        let _logAutoRefreshTimer = null;
+
+        // Normalize any log entry (new object format or legacy string) into a common shape.
+        function normalizeLog(log) {
+            if (typeof log === 'string') {
+                const reqMatch = log.match(/\[(?:REQ|TEST)-([a-zA-Z0-9]+)\]/);
+                return {
+                    timestamp: null, requestId: reqMatch ? reqMatch[1] : 'legacy',
+                    method: '', endpoint: log, provider: '', status: null,
+                    responseTime: null, error: null, keyUsed: null, failedKeys: [],
+                    proxyUsed: null, _raw: true
+                };
+            }
+            return {
+                timestamp: log.timestamp || null,
+                requestId: log.requestId || 'unknown',
+                method: log.method || '',
+                endpoint: log.endpoint || '',
+                provider: log.provider || '',
+                status: (log.status === 0 || log.status) ? log.status : null,
+                responseTime: log.responseTime != null ? log.responseTime : null,
+                error: log.error || null,
+                keyUsed: log.keyUsed || null,
+                failedKeys: Array.isArray(log.failedKeys) ? log.failedKeys : [],
+                proxyUsed: log.proxyUsed || null,
+                _raw: false
+            };
+        }
+
         async function refreshLogs() {
             try {
                 const response = await fetch('/admin/api/logs');
                 const data = await response.json();
-                
-                const logsContainer = document.getElementById('logsContainer');
-                if (!data.logs || data.logs.length === 0) {
-                    logsContainer.textContent = 'No logs available';
-                    return;
+                const logs = Array.isArray(data.logs) ? data.logs : [];
+
+                // Deduplicate by requestId - keep the LAST (most complete) entry
+                const seen = new Map();
+                for (const log of logs) {
+                    const key = (log && typeof log === 'object' && log.requestId)
+                        ? log.requestId
+                        : (typeof log === 'string'
+                            ? (log.match(/\[(?:REQ|TEST)-([a-zA-Z0-9]+)\]/)?.[1] || log)
+                            : JSON.stringify(log));
+                    seen.set(key, log);
                 }
-                
-                // Check if we're receiving the new JSON format
-                const isJsonFormat = data.format === 'json' || (data.logs.length > 0 && typeof data.logs[0] === 'object');
-                
-                let processedLogs;
-                
-                if (isJsonFormat) {
-                    // Deduplicate logs - keep the LAST (most complete) entry per requestId
-                    const seenRequests = new Map();
+                _logsCache = [...seen.values()].reverse(); // newest first
 
-                    for (const log of data.logs) {
-                        let key;
-                        if (typeof log === 'object' && log.requestId) {
-                            key = log.requestId;
-                        } else if (typeof log === 'string') {
-                            const reqIdMatch = log.match(/\[([a-zA-Z0-9]+)\]/);
-                            key = reqIdMatch ? reqIdMatch[1] : log;
-                        } else {
-                            key = JSON.stringify(log);
-                        }
-                        // Always overwrite - last entry wins (has status + key info)
-                        seenRequests.set(key, log);
-                    }
-                    const uniqueLogs = [...seenRequests.values()].reverse();
-
-                    // New JSON format - create formatted display
-                    processedLogs = uniqueLogs.map(log => {
-                        if (typeof log === 'string') {
-                            // Legacy string format - display as is with view button if possible
-                            const testMatch = log.match(/\[TEST-([a-zA-Z0-9]+)\]/);
-                            const reqMatch = log.match(/\[REQ-([a-zA-Z0-9]+)\]/);
-                            if (testMatch) {
-                                const testId = testMatch[1];
-                                return log + ` <button onclick="viewResponse('${testId}')" class="ml-2 text-blue-400 hover:text-blue-300 underline cursor-pointer text-xs">View Details</button>`;
-                            } else if (reqMatch) {
-                                const requestId = reqMatch[1];
-                                return log + ` <button onclick="viewResponse('${requestId}')" class="ml-2 text-blue-400 hover:text-blue-300 underline cursor-pointer text-xs">View Details</button>`;
-                            }
-                            return log;
-                        } else {
-                            // New JSON format - create structured display
-                            const timestamp = new Date(log.timestamp).toLocaleTimeString();
-                            const status = log.status ? `(${log.status})` : '';
-                            const responseTime = log.responseTime ? `${log.responseTime}ms` : '';
-                            const error = log.error ? ` ERROR: ${log.error}` : '';
-                            
-                            // Color coding based on status
-                            let statusColor = 'text-green-400';
-                            if (log.status >= 400) {
-                                statusColor = 'text-red-400';
-                            } else if (log.status >= 300) {
-                                statusColor = 'text-yellow-400';
-                            }
-                            
-                            // Key usage info
-                            let keyInfoHtml = '';
-                            if (log.keyUsed) {
-                                keyInfoHtml += ` <span class="text-green-300" title="Key used successfully">key:${log.keyUsed}</span>`;
-                            }
-                            if (log.failedKeys && log.failedKeys.length > 0) {
-                                const failedList = log.failedKeys.map(fk => `${fk.key}(${fk.status || 'err'})`).join(', ');
-                                keyInfoHtml += ` <span class="text-orange-400" title="Failed keys">failed:[${failedList}]</span>`;
-                            }
-
-                            const logLine = `<span class="text-gray-400">${timestamp}</span> <span class="text-blue-400">[${log.requestId}]</span> <span class="text-white">${log.method} ${log.endpoint}</span> <span class="text-cyan-400">(${log.provider})</span> <span class="${statusColor}">${status}</span> <span class="text-gray-400">${responseTime}</span>${keyInfoHtml}<span class="text-red-400">${error}</span>`;
-                            
-                            // Add view button if we have detailed response data
-                            if (log.requestId && log.requestId !== 'unknown') {
-                                return logLine + ` <button onclick="viewResponse('${log.requestId}')" class="ml-2 text-blue-400 hover:text-blue-300 underline cursor-pointer text-xs">View Details</button>`;
-                            }
-                            return logLine;
-                        }
-                    }).join('\n');
-                } else {
-                    // Legacy string format - deduplicate based on request ID
-                    const seenIds = new Set();
-                    const uniqueLogs = [];
-                    
-                    for (const log of data.logs) {
-                        // Extract any ID from the log string
-                        const idMatch = log.match(/\[([a-zA-Z0-9]+)\]/);
-                        const logId = idMatch ? idMatch[1] : log;
-                        
-                        if (!seenIds.has(logId)) {
-                            seenIds.add(logId);
-                            uniqueLogs.push(log);
-                        }
-                    }
-                    
-                    // Legacy string format - reverse so latest is first
-                    uniqueLogs.reverse();
-                    processedLogs = uniqueLogs.map(log => {
-                        const testMatch = log.match(/\[TEST-([a-zA-Z0-9]+)\]/);
-                        if (testMatch) {
-                            const testId = testMatch[1];
-                            return log + ` <button onclick="viewResponse('${testId}')" class="ml-2 text-blue-400 hover:text-blue-300 underline cursor-pointer text-xs">View Details</button>`;
-                        }
-                        
-                        const reqMatch = log.match(/\[REQ-([a-zA-Z0-9]+)\]/);
-                        if (reqMatch) {
-                            const requestId = reqMatch[1];
-                            return log + ` <button onclick="viewResponse('${requestId}')" class="ml-2 text-blue-400 hover:text-blue-300 underline cursor-pointer text-xs">View Details</button>`;
-                        }
-                        
-                        return log;
-                    }).join('\n');
-                }
-                
-                logsContainer.innerHTML = processedLogs || 'No logs available';
-
-                // Latest logs are already at top, scroll to top
-                logsContainer.scrollTop = 0;
+                populateLogProviderFilter();
+                renderLogs();
             } catch (error) {
-                document.getElementById('logsContainer').textContent = 'Failed to load logs: ' + error.message;
+                const body = document.getElementById('logsTableBody');
+                if (body) body.innerHTML = '';
+                const empty = document.getElementById('logsEmpty');
+                if (empty) { empty.classList.remove('hidden'); empty.textContent = 'Failed to load logs: ' + error.message; }
             }
+        }
+
+        function populateLogProviderFilter() {
+            const sel = document.getElementById('logProviderFilter');
+            if (!sel) return;
+            const current = sel.value;
+            const providers = [...new Set(_logsCache.map(l => normalizeLog(l).provider).filter(p => p && p !== 'unknown'))].sort();
+            sel.innerHTML = '<option value="">All providers</option>' +
+                providers.map(p => `<option value="${escapeHtml(p)}">${escapeHtml(p)}</option>`).join('');
+            if (providers.includes(current)) sel.value = current;
+        }
+
+        function statusMatchesFilter(status, filter) {
+            if (!filter) return true;
+            if (status == null) return false;
+            if (filter === 'success') return status >= 200 && status < 300;
+            if (filter === 'redirect') return status >= 300 && status < 400;
+            if (filter === 'clienterror') return status >= 400 && status < 500;
+            if (filter === 'servererror') return status >= 500;
+            return true;
+        }
+
+        function statusBadge(status) {
+            if (status == null) return '<span class="inline-block px-1.5 py-0.5 rounded bg-muted text-muted-foreground">—</span>';
+            let cls = 'bg-green-500/15 text-green-400 border-green-500/30';
+            if (status >= 500) cls = 'bg-red-500/15 text-red-400 border-red-500/30';
+            else if (status >= 400) cls = 'bg-orange-500/15 text-orange-400 border-orange-500/30';
+            else if (status >= 300) cls = 'bg-yellow-500/15 text-yellow-400 border-yellow-500/30';
+            return `<span class="inline-block px-1.5 py-0.5 rounded border font-medium ${cls}">${status}</span>`;
+        }
+
+        function logRowHtml(log) {
+            const time = log.timestamp ? new Date(log.timestamp).toLocaleTimeString() : '—';
+            const timeTitle = log.timestamp ? new Date(log.timestamp).toLocaleString() : '';
+
+            // Request cell: method chip + endpoint
+            let requestCell;
+            if (log._raw) {
+                requestCell = `<span class="text-muted-foreground break-all">${escapeHtml(log.endpoint)}</span>`;
+            } else {
+                const method = log.method
+                    ? `<span class="inline-block px-1.5 py-0.5 rounded bg-muted text-foreground font-medium mr-1.5">${escapeHtml(log.method)}</span>` : '';
+                requestCell = `${method}<span class="font-mono text-foreground align-middle inline-block max-w-[320px] truncate" title="${escapeHtml(log.endpoint)}">${escapeHtml(log.endpoint || '—')}</span>`;
+            }
+
+            const provider = log.provider
+                ? `<span class="text-cyan-400">${escapeHtml(log.provider)}</span>` : '<span class="text-muted-foreground">—</span>';
+
+            const latency = log.responseTime != null
+                ? `<span class="text-muted-foreground tabular-nums">${log.responseTime}ms</span>` : '<span class="text-muted-foreground">—</span>';
+
+            // Key cell: successful key + failed-key count chip
+            let keyCell = '<span class="text-muted-foreground">—</span>';
+            if (log.keyUsed) {
+                keyCell = `<span class="font-mono text-green-400" title="Key used">${escapeHtml(log.keyUsed)}</span>`;
+            }
+            if (log.failedKeys && log.failedKeys.length > 0) {
+                const failedList = log.failedKeys.map(fk => `${fk.key} (${fk.status || 'err'})`).join(', ');
+                keyCell += ` <span class="inline-block px-1 py-0.5 rounded bg-orange-500/15 text-orange-400 text-[10px]" title="Rotated past: ${escapeHtml(failedList)}">↻${log.failedKeys.length}</span>`;
+            }
+
+            // Proxy cell: which proxy routed this request (or Direct)
+            let proxyCell;
+            if (log.proxyUsed) {
+                proxyCell = `<span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-purple-500/15 text-purple-300 border border-purple-500/30 font-mono max-w-[200px] truncate" title="${escapeHtml(log.proxyUsed)}">
+                    <svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                    <span class="truncate">${escapeHtml(log.proxyUsed)}</span></span>`;
+            } else {
+                proxyCell = '<span class="text-muted-foreground" title="Sent directly, no proxy">direct</span>';
+            }
+
+            const errorRow = log.error
+                ? `<div class="text-red-400 text-[11px] mt-0.5 break-all" title="${escapeHtml(log.error)}">${escapeHtml(log.error)}</div>` : '';
+
+            const detailsBtn = (log.requestId && log.requestId !== 'unknown' && log.requestId !== 'legacy')
+                ? `<button onclick="viewResponse('${escapeHtml(log.requestId)}')" class="text-blue-400 hover:text-blue-300 underline cursor-pointer whitespace-nowrap">View</button>`
+                : '';
+
+            return `<tr class="hover:bg-muted/40 align-top">
+                <td class="px-2.5 py-1.5 whitespace-nowrap text-muted-foreground tabular-nums" title="${escapeHtml(timeTitle)}">${escapeHtml(time)}</td>
+                <td class="px-2.5 py-1.5">${requestCell}${errorRow}</td>
+                <td class="px-2.5 py-1.5 whitespace-nowrap">${provider}</td>
+                <td class="px-2.5 py-1.5 whitespace-nowrap">${statusBadge(log.status)}</td>
+                <td class="px-2.5 py-1.5 whitespace-nowrap text-right">${latency}</td>
+                <td class="px-2.5 py-1.5 whitespace-nowrap">${keyCell}</td>
+                <td class="px-2.5 py-1.5 whitespace-nowrap">${proxyCell}</td>
+                <td class="px-2.5 py-1.5 whitespace-nowrap text-right">${detailsBtn}</td>
+            </tr>`;
+        }
+
+        function renderLogs() {
+            const body = document.getElementById('logsTableBody');
+            if (!body) return;
+            const q = (document.getElementById('logSearch')?.value || '').toLowerCase().trim();
+            const provFilter = document.getElementById('logProviderFilter')?.value || '';
+            const statFilter = document.getElementById('logStatusFilter')?.value || '';
+            const proxyFilter = document.getElementById('logProxyFilter')?.value || '';
+
+            const rows = [];
+            for (const raw of _logsCache) {
+                const log = normalizeLog(raw);
+                if (provFilter && log.provider !== provFilter) continue;
+                if (statFilter && !statusMatchesFilter(log.status, statFilter)) continue;
+                if (proxyFilter === 'proxy' && !log.proxyUsed) continue;
+                if (proxyFilter === 'direct' && log.proxyUsed) continue;
+                if (q) {
+                    const hay = [
+                        log.endpoint, log.method, log.provider, log.status, log.keyUsed,
+                        log.proxyUsed, log.error, (log.failedKeys || []).map(f => f.key).join(' ')
+                    ].join(' ').toLowerCase();
+                    if (!hay.includes(q)) continue;
+                }
+                rows.push(logRowHtml(log));
+            }
+
+            body.innerHTML = rows.join('');
+            const empty = document.getElementById('logsEmpty');
+            if (empty) {
+                empty.classList.toggle('hidden', rows.length > 0);
+                if (rows.length === 0) {
+                    empty.textContent = _logsCache.length === 0
+                        ? 'No logs available yet. Make an API request to see it here.'
+                        : 'No logs match the current filters.';
+                }
+            }
+            const count = document.getElementById('logCount');
+            if (count) {
+                const filtered = rows.length !== _logsCache.length ? `${rows.length} shown · ` : '';
+                count.textContent = `${filtered}${_logsCache.length} request${_logsCache.length === 1 ? '' : 's'}`;
+            }
+        }
+
+        function toggleLogAutoRefresh() {
+            const on = document.getElementById('logAutoRefresh')?.checked;
+            if (_logAutoRefreshTimer) { clearInterval(_logAutoRefreshTimer); _logAutoRefreshTimer = null; }
+            if (on) {
+                _logAutoRefreshTimer = setInterval(refreshLogs, 5000);
+                refreshLogs();
+            }
+        }
+
+        // --- Response viewer state ---
+        let _rvResponseRaw = '';   // raw (pretty-printed) text for copy
+        let _rvRequestRaw = '';
+        let _rvActive = 'response';
+
+        // Segmented-tab styling
+        const RV_TAB_ACTIVE = 'px-3 py-1 rounded text-xs font-medium transition-colors bg-primary text-primary-foreground';
+        const RV_TAB_INACTIVE = 'px-3 py-1 rounded text-xs font-medium transition-colors text-muted-foreground hover:text-foreground';
+        const RV_TAB_DISABLED = 'px-3 py-1 rounded text-xs font-medium text-muted-foreground/40 cursor-not-allowed';
+
+        // Lightweight JSON syntax highlighter (keys / strings / numbers / booleans / null)
+        function highlightJson(jsonString) {
+            const esc = jsonString.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            return esc.replace(/("(\\u[a-fA-F0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false)\b|\bnull\b|-?\d+(?:\.\d+)?(?:[eE][+\-]?\d+)?)/g, (m) => {
+                let cls = 'text-emerald-300'; // number
+                if (/^"/.test(m)) cls = /:$/.test(m) ? 'text-sky-300' : 'text-amber-200'; // key : string
+                else if (/true|false/.test(m)) cls = 'text-purple-300';
+                else if (/null/.test(m)) cls = 'text-rose-300';
+                return `<span class="${cls}">${m}</span>`;
+            });
+        }
+
+        // Pretty-print + highlight into a <pre>, returning the raw pretty text
+        function renderIntoPre(preEl, raw) {
+            const text = (raw == null) ? '' : String(raw);
+            let pretty;
+            try {
+                pretty = JSON.stringify(JSON.parse(text), null, 2);
+                preEl.innerHTML = highlightJson(pretty);
+            } catch (e) {
+                pretty = text;
+                preEl.textContent = pretty; // not JSON — plain text, no highlight
+            }
+            return pretty;
+        }
+
+        function rvStatusBadge(status, statusText) {
+            const el = document.getElementById('rvStatusBadge');
+            const s = parseInt(status, 10);
+            let cls = 'bg-muted text-muted-foreground border-border';
+            if (s >= 200 && s < 300) cls = 'bg-green-500/15 text-green-400 border-green-500/30';
+            else if (s >= 300 && s < 400) cls = 'bg-yellow-500/15 text-yellow-400 border-yellow-500/30';
+            else if (s >= 400 && s < 500) cls = 'bg-orange-500/15 text-orange-400 border-orange-500/30';
+            else if (s >= 500) cls = 'bg-red-500/15 text-red-400 border-red-500/30';
+            el.className = `inline-block px-2 py-0.5 rounded-md text-xs font-semibold border ${cls}`;
+            el.textContent = isNaN(s) ? '—' : `${s}${statusText ? ' ' + statusText : ''}`;
+        }
+
+        function rvChip(label, value, tone) {
+            const tones = {
+                default: 'bg-muted text-muted-foreground',
+                cyan: 'bg-cyan-500/15 text-cyan-300',
+                purple: 'bg-purple-500/15 text-purple-300 border border-purple-500/30',
+                green: 'bg-green-500/15 text-green-400',
+                orange: 'bg-orange-500/15 text-orange-400'
+            };
+            return `<span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] ${tones[tone] || tones.default}">
+                <span class="opacity-60">${escapeHtml(label)}</span><span class="font-medium font-mono">${escapeHtml(value)}</span></span>`;
+        }
+
+        function bytesHuman(n) {
+            if (n == null) return null;
+            if (n < 1024) return n + ' B';
+            if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB';
+            return (n / (1024 * 1024)).toFixed(2) + ' MB';
         }
 
         async function viewResponse(testId) {
             try {
                 const response = await fetch(`/admin/api/response/${testId}`);
                 if (!response.ok) {
-                    alert('Response data not found');
+                    showErrorToast ? showErrorToast('Response data not found') : alert('Response data not found');
                     return;
                 }
-                
                 const data = await response.json();
-                
-                // Update dialog content
-                document.getElementById('responseInfo').textContent = 
-                    `${data.method} ${data.endpoint} (${data.apiType}) → ${data.status} ${data.statusText} | ${data.contentType}`;
-                
-                // Format JSON response
-                let formattedResponse;
-                try {
-                    const jsonData = JSON.parse(data.responseData);
-                    formattedResponse = JSON.stringify(jsonData, null, 2);
-                } catch (e) {
-                    // Not JSON, show as plain text
-                    formattedResponse = data.responseData;
-                }
-                
-                document.getElementById('responseContent').textContent = formattedResponse;
-                
-                // Handle request body tab
+
+                // Header
+                rvStatusBadge(data.status, data.statusText);
+                document.getElementById('rvMethod').textContent = data.method || '—';
+                const epEl = document.getElementById('rvEndpoint');
+                epEl.textContent = data.endpoint || '';
+                epEl.title = data.endpoint || '';
+
+                // Meta chips
+                const size = bytesHuman(data.responseData ? new Blob([data.responseData]).size : null);
+                const chips = [];
+                if (data.provider) chips.push(rvChip('provider', data.provider, 'cyan'));
+                if (data.apiType) chips.push(rvChip('type', data.apiType, 'default'));
+                if (data.streaming) chips.push(`<span class="inline-block px-1.5 py-0.5 rounded text-[11px] bg-blue-500/15 text-blue-300">streaming</span>`);
+                if (data.contentType) chips.push(rvChip('content-type', data.contentType, 'default'));
+                if (size) chips.push(rvChip('size', size, 'default'));
+                if (data.keyInfo && data.keyInfo.keyUsed) chips.push(rvChip('key', data.keyInfo.keyUsed, 'green'));
+                if (data.keyInfo && data.keyInfo.failedKeys && data.keyInfo.failedKeys.length)
+                    chips.push(rvChip('rotated', '↻' + data.keyInfo.failedKeys.length, 'orange'));
+                if (data.proxyUsed) chips.push(rvChip('proxy', data.proxyUsed, 'purple'));
+                else chips.push(`<span class="inline-block px-1.5 py-0.5 rounded text-[11px] bg-muted text-muted-foreground">direct</span>`);
+                document.getElementById('rvMeta').innerHTML = chips.join('');
+
+                // Body panes
+                _rvResponseRaw = renderIntoPre(document.getElementById('responseContent'), data.responseData);
+
                 const requestTab = document.getElementById('requestTab');
                 const requestContent = document.getElementById('requestContent');
-                
-                if (data.requestBody && data.requestBody.trim()) {
-                    // Show and enable request tab if there's a request body
-                    requestTab.classList.remove('hidden');
+                if (data.requestBody && String(data.requestBody).trim()) {
                     requestTab.disabled = false;
                     requestTab.title = '';
-                    requestTab.className = 'px-4 py-2 rounded-md text-sm font-medium btn-secondary';
-                    
-                    // Format request body
-                    let formattedRequest;
-                    try {
-                        const requestJson = JSON.parse(data.requestBody);
-                        formattedRequest = JSON.stringify(requestJson, null, 2);
-                    } catch (e) {
-                        formattedRequest = data.requestBody;
-                    }
-                    
-                    requestContent.textContent = formattedRequest;
+                    _rvRequestRaw = renderIntoPre(requestContent, data.requestBody);
                 } else {
-                    // Show but disable request tab if no request body
-                    requestTab.classList.remove('hidden');
                     requestTab.disabled = true;
-                    requestTab.title = 'No request body available';
-                    requestTab.className = 'px-4 py-2 rounded-md text-sm font-medium bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50';
+                    requestTab.title = 'No request body for this request';
+                    _rvRequestRaw = '';
                     requestContent.textContent = 'No request body data available for this request.';
                 }
-                
-                // Start with response tab active
+
                 switchResponseTab('response');
-                
-                // Show dialog
                 document.getElementById('responseDialog').classList.remove('hidden');
             } catch (error) {
-                alert('Failed to load response: ' + error.message);
+                showErrorToast ? showErrorToast('Failed to load response: ' + error.message) : alert('Failed to load response: ' + error.message);
             }
         }
 
@@ -3501,33 +3814,44 @@ ${googApiKeyHeader}  -H "Content-Type: application/json" \\
             const requestTab = document.getElementById('requestTab');
             const responseContent = document.getElementById('responseContent');
             const requestContent = document.getElementById('requestContent');
-            
-            // Don't switch if request tab is disabled and trying to switch to it
-            if (tab === 'request' && requestTab.disabled) {
-                return;
-            }
-            
-            if (tab === 'response') {
-                // Activate response tab
-                responseTab.className = 'px-4 py-2 rounded-md text-sm font-medium btn-primary';
-                // Only update request tab style if it's not disabled
-                if (!requestTab.disabled) {
-                    requestTab.className = 'px-4 py-2 rounded-md text-sm font-medium btn-secondary';
-                }
-                responseContent.classList.remove('hidden');
-                requestContent.classList.add('hidden');
-            } else {
-                // Activate request tab (only reachable if not disabled)
-                requestTab.className = 'px-4 py-2 rounded-md text-sm font-medium btn-primary';
-                responseTab.className = 'px-4 py-2 rounded-md text-sm font-medium btn-secondary';
-                requestContent.classList.remove('hidden');
-                responseContent.classList.add('hidden');
-            }
+
+            if (tab === 'request' && requestTab.disabled) return;
+            _rvActive = tab;
+
+            responseTab.className = tab === 'response' ? RV_TAB_ACTIVE : RV_TAB_INACTIVE;
+            requestTab.className = requestTab.disabled ? RV_TAB_DISABLED : (tab === 'request' ? RV_TAB_ACTIVE : RV_TAB_INACTIVE);
+
+            responseContent.classList.toggle('hidden', tab !== 'response');
+            requestContent.classList.toggle('hidden', tab !== 'request');
+        }
+
+        function toggleResponseWrap() {
+            const btn = document.getElementById('rvWrapBtn');
+            const on = document.getElementById('responseContent').classList.toggle('whitespace-pre-wrap');
+            document.getElementById('responseContent').classList.toggle('whitespace-pre', !on);
+            document.getElementById('requestContent').classList.toggle('whitespace-pre-wrap', on);
+            document.getElementById('requestContent').classList.toggle('whitespace-pre', !on);
+            document.getElementById('responseContent').classList.toggle('break-all', on);
+            document.getElementById('requestContent').classList.toggle('break-all', on);
+            btn.classList.toggle('btn-primary', on);
+            btn.classList.toggle('btn-secondary', !on);
+        }
+
+        function copyResponseView(btn) {
+            const raw = _rvActive === 'request' ? _rvRequestRaw : _rvResponseRaw;
+            copyToClipboard(raw, `${_rvActive === 'request' ? 'Request' : 'Response'} copied to clipboard!`);
         }
 
         function closeResponseDialog() {
             document.getElementById('responseDialog').classList.add('hidden');
         }
+
+        // Esc closes the response viewer
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && !document.getElementById('responseDialog').classList.contains('hidden')) {
+                closeResponseDialog();
+            }
+        });
         
         // Load logs when logs tab is shown
         function showTab(tabName) {
@@ -3551,10 +3875,143 @@ ${googApiKeyHeader}  -H "Content-Type: application/json" \\
             activeBtn.classList.add('active', 'text-foreground', 'border-primary');
             activeBtn.classList.remove('text-muted-foreground');
             
-            // Load logs if logs tab is selected
+            // Load logs if logs tab is selected; pause auto-refresh polling elsewhere
             if (tabName === 'logs') {
                 refreshLogs();
+                if (document.getElementById('logAutoRefresh')?.checked && !_logAutoRefreshTimer) {
+                    _logAutoRefreshTimer = setInterval(refreshLogs, 5000);
+                }
+            } else if (_logAutoRefreshTimer) {
+                clearInterval(_logAutoRefreshTimer);
+                _logAutoRefreshTimer = null;
             }
+
+            // Load proxy settings when the proxy tab is selected
+            if (tabName === 'proxy') {
+                loadProxySettings();
+            }
+
+            // Load settings when the settings tab is selected
+            if (tabName === 'settings') {
+                loadTelegramSettings();
+            }
+        }
+
+        // ===== Proxy settings =====
+        let proxyState = { enabled: false, proxies: [] };
+
+        async function loadProxySettings() {
+            try {
+                const res = await fetch('/admin/api/proxy');
+                if (!res.ok) throw new Error('Failed to load proxy settings');
+                const data = await res.json();
+                proxyState = data;
+                document.getElementById('proxyEnabled').checked = !!data.enabled;
+                document.getElementById('proxyUrls').value = (data.proxies || []).map(p => p.url).join('\n');
+                renderProxyList(data.proxies || []);
+            } catch (e) {
+                showError('proxyError', e.message);
+            }
+        }
+
+        function renderProxyList(proxies) {
+            const container = document.getElementById('proxyListContainer');
+            const empty = document.getElementById('proxyListEmpty');
+            container.innerHTML = '';
+            if (!proxies || proxies.length === 0) {
+                empty.classList.remove('hidden');
+                return;
+            }
+            empty.classList.add('hidden');
+            proxies.forEach((p) => {
+                const row = document.createElement('div');
+                row.className = 'flex items-center justify-between gap-3 border border-border rounded p-2 bg-muted/20';
+                row.innerHTML = `
+                    <code class="text-xs text-foreground truncate flex-1" title="${escapeHtml(p.masked)}">${escapeHtml(p.masked)}</code>
+                    <span class="proxy-test-result text-xs text-muted-foreground whitespace-nowrap"></span>
+                    <button class="btn btn-secondary px-2 py-1 text-xs font-medium flex-shrink-0">Test</button>
+                `;
+                const btn = row.querySelector('button');
+                const resultEl = row.querySelector('.proxy-test-result');
+                btn.onclick = () => testProxy(p.url, btn, resultEl);
+                container.appendChild(row);
+            });
+        }
+
+        function escapeHtml(str) {
+            return String(str).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+        }
+
+        async function saveProxySettings(btn) {
+            const original = btn ? btn.textContent : '';
+            if (btn) { btn.disabled = true; btn.textContent = 'Saving...'; }
+            try {
+                const enabled = document.getElementById('proxyEnabled').checked;
+                const proxies = document.getElementById('proxyUrls').value
+                    .split('\n')
+                    .map(s => s.trim())
+                    .filter(s => s.length > 0);
+
+                const res = await fetch('/admin/api/proxy', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ enabled, proxies }),
+                });
+                const data = await res.json();
+                if (!res.ok || !data.success) throw new Error(data.error || 'Failed to save');
+
+                showSuccess('proxySuccess', `Saved ${data.count} proxy(ies). Routing ${data.enabled ? 'ENABLED' : 'disabled'}.`);
+                await loadProxySettings();
+            } catch (e) {
+                showError('proxyError', e.message);
+            } finally {
+                if (btn) { btn.disabled = false; btn.textContent = original; }
+            }
+        }
+
+        async function testProxy(url, btn, resultEl) {
+            const original = btn ? btn.textContent : '';
+            if (btn) { btn.disabled = true; btn.textContent = 'Testing...'; }
+            if (resultEl) { resultEl.textContent = ''; resultEl.className = 'proxy-test-result text-xs text-muted-foreground whitespace-nowrap'; }
+            try {
+                const res = await fetch('/admin/api/proxy/test', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ proxy: url }),
+                });
+                const data = await res.json();
+                if (data.success) {
+                    if (resultEl) {
+                        resultEl.textContent = `IP: ${data.ip} (${data.ms}ms)`;
+                        resultEl.className = 'proxy-test-result text-xs text-green-600 whitespace-nowrap';
+                    }
+                } else {
+                    if (resultEl) {
+                        resultEl.textContent = `✗ ${data.error}`;
+                        resultEl.className = 'proxy-test-result text-xs text-destructive whitespace-nowrap';
+                    }
+                }
+            } catch (e) {
+                if (resultEl) {
+                    resultEl.textContent = `✗ ${e.message}`;
+                    resultEl.className = 'proxy-test-result text-xs text-destructive whitespace-nowrap';
+                }
+            } finally {
+                if (btn) { btn.disabled = false; btn.textContent = original; }
+            }
+        }
+
+        async function testAllProxies(btn) {
+            const original = btn ? btn.textContent : '';
+            if (btn) { btn.disabled = true; btn.textContent = 'Testing...'; }
+            const rows = document.querySelectorAll('#proxyListContainer > div');
+            const proxies = proxyState.proxies || [];
+            for (let i = 0; i < rows.length; i++) {
+                const rowBtn = rows[i].querySelector('button');
+                const resultEl = rows[i].querySelector('.proxy-test-result');
+                if (proxies[i]) await testProxy(proxies[i].url, rowBtn, resultEl);
+            }
+            if (btn) { btn.disabled = false; btn.textContent = original; }
         }
         
         // Utility functions
@@ -3725,109 +4182,8 @@ ${googApiKeyHeader}  -H "Content-Type: application/json" \\
             checkAuth();
         });
     </script>
-<!-- Settings Modal -->
-<div id="settingsModal" class="fixed inset-0 z-50 hidden">
-    <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" onclick="closeSettingsModal()"></div>
-    <div class="absolute inset-0 flex items-center justify-center p-4">
-        <div class="bg-card border border-border rounded-lg shadow-xl w-full max-w-lg relative">
-            <div class="flex items-center justify-between p-4 border-b border-border">
-                <h3 class="text-lg font-semibold text-foreground">Settings</h3>
-                <button onclick="closeSettingsModal()" class="text-muted-foreground hover:text-foreground p-1">
-                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
-            </div>
-            <div class="p-4 space-y-5 max-h-[70vh] overflow-y-auto">
-                <!-- Default Status Codes Section -->
-                <div>
-                    <h4 class="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                        </svg>
-                        Key Rotation
-                    </h4>
-                    <div class="space-y-3">
-                        <div>
-                            <label class="block text-xs font-medium text-muted-foreground mb-1">Default Status Codes to Rotate <span class="text-muted-foreground font-normal">(comma-separated)</span></label>
-                            <input type="text" id="defaultStatusCodes" class="input-field w-full px-3 py-2 rounded-md text-sm" placeholder="429" value="429">
-                        </div>
-                        <p class="text-xs text-muted-foreground">When the API returns any of these status codes, the proxy will rotate to the next API key. This is reflected in all generated cURL commands.</p>
-                        <div class="mt-3">
-                            <label class="block text-xs font-medium text-muted-foreground mb-1">Keep-Alive Interval <span class="text-muted-foreground font-normal">(minutes, 0 to disable)</span></label>
-                            <input type="number" id="keepAliveMinutes" class="input-field w-full px-3 py-2 rounded-md text-sm" placeholder="10" value="10" min="0" step="1">
-                        </div>
-                        <p class="text-xs text-muted-foreground">Pings the server periodically to prevent hosting platforms from shutting it down due to inactivity. Set to 0 to disable.</p>
-                    </div>
-                </div>
-
-                <hr class="border-border">
-
-                <!-- Telegram Bot Section -->
-                <div>
-                    <h4 class="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
-                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69a.2.2 0 00-.05-.18c-.06-.05-.14-.03-.21-.02-.09.02-1.49.95-4.22 2.79-.4.27-.76.41-1.08.4-.36-.01-1.04-.2-1.55-.37-.63-.2-1.12-.31-1.08-.66.02-.18.27-.36.74-.55 2.92-1.27 4.86-2.11 5.83-2.51 2.78-1.16 3.35-1.36 3.73-1.36.08 0 .27.02.39.12.1.08.13.19.14.27-.01.06.01.24 0 .38z"/>
-                        </svg>
-                        Telegram Bot
-                    </h4>
-
-                    <div class="space-y-3">
-                        <div>
-                            <label class="block text-xs font-medium text-muted-foreground mb-1">Bot Token</label>
-                            <input type="password" id="telegramBotToken" class="input-field w-full px-3 py-2 rounded-md text-sm" placeholder="123456789:ABCdefGhIjKlMnOpQrStUvWxYz">
-                        </div>
-                        <div>
-                            <label class="block text-xs font-medium text-muted-foreground mb-1">Allowed User IDs <span class="text-muted-foreground font-normal">(comma-separated, leave empty to allow all)</span></label>
-                            <input type="text" id="telegramAllowedUsers" class="input-field w-full px-3 py-2 rounded-md text-sm" placeholder="123456789, 987654321">
-                        </div>
-                        <div id="telegramBotStatus" class="text-xs"></div>
-
-                        <button onclick="saveTelegramSettings()" class="btn btn-primary w-full py-2 text-sm font-medium">Save Telegram Settings</button>
-
-                        <div class="border border-border rounded-md p-3 bg-muted/30">
-                            <p class="text-xs font-medium text-foreground mb-2">How to set up:</p>
-                            <ol class="text-xs text-muted-foreground space-y-1.5 list-decimal list-inside">
-                                <li>Open Telegram and search for <strong>@BotFather</strong></li>
-                                <li>Send <code class="bg-muted px-1 rounded">/newbot</code> and follow the prompts</li>
-                                <li>Copy the bot token and paste it above</li>
-                                <li>To get your User ID, search for <strong>@userinfobot</strong> on Telegram and send it any message</li>
-                                <li>Add your User ID to the allowed list (or leave empty to allow anyone)</li>
-                            </ol>
-                            <div class="mt-2 pt-2 border-t border-border">
-                                <p class="text-xs font-medium text-foreground mb-1">Bot commands:</p>
-                                <div class="text-xs text-muted-foreground space-y-0.5">
-                                    <p><code class="bg-muted px-1 rounded">/models</code> - Select provider & model</p>
-                                    <p><code class="bg-muted px-1 rounded">/clear</code> - Clear conversation history</p>
-                                    <p><code class="bg-muted px-1 rounded">/logs</code> - View recent API logs</p>
-                                    <p><code class="bg-muted px-1 rounded">/status</code> - Show current model info</p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
 
 <script>
-    function openSettingsModal() {
-        document.getElementById('settingsModal').classList.remove('hidden');
-        loadTelegramSettings();
-    }
-
-    function closeSettingsModal() {
-        document.getElementById('settingsModal').classList.add('hidden');
-    }
-
-    // Close on Escape
-    document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && !document.getElementById('settingsModal').classList.contains('hidden')) {
-            closeSettingsModal();
-        }
-    });
-
     async function loadTelegramSettings() {
         try {
             const response = await fetch('/admin/api/telegram');

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const ProxyManager = require('./proxyManager');
 
 class Config {
   constructor() {
@@ -8,6 +9,9 @@ class Config {
     this.geminiApiKeys = [];
     this.openaiApiKeys = [];
     this.baseUrl = null;
+    this.proxyUrls = [];
+    this.proxyEnabled = false;
+    this.proxyManager = new ProxyManager([], false);
     this.loadConfig();
   }
 
@@ -60,6 +64,9 @@ class Config {
     // Parse new provider format and maintain backward compatibility
     this.parseProviders(envVars);
     this.parseBackwardCompatibility(envVars);
+
+    // Parse outbound proxy configuration
+    this.parseProxyConfig(envVars);
 
     console.log(`[CONFIG] Found ${this.providers.size} providers configured`);
 
@@ -254,6 +261,37 @@ class Config {
         baseUrl: baseUrl
       });
     }
+  }
+
+  parseProxyConfig(envVars) {
+    this.proxyUrls = (envVars.PROXY_URLS || '')
+      .split(',')
+      .map(u => u.trim())
+      .filter(u => u.length > 0);
+
+    this.proxyEnabled = (envVars.PROXY_ENABLED || '').trim().toLowerCase() === 'true'
+      && this.proxyUrls.length > 0;
+
+    this.proxyManager = new ProxyManager(this.proxyUrls, this.proxyEnabled);
+
+    if (this.proxyEnabled) {
+      const masked = this.proxyUrls.map(u => ProxyManager.maskProxyUrl(u));
+      console.log(`[CONFIG] Outbound proxy ENABLED — rotating across ${this.proxyUrls.length} proxy(ies): [${masked.join(', ')}]`);
+    } else if (this.proxyUrls.length > 0) {
+      console.log(`[CONFIG] ${this.proxyUrls.length} proxy(ies) configured but proxy routing is DISABLED`);
+    }
+  }
+
+  getProxyManager() {
+    return this.proxyManager;
+  }
+
+  getProxyUrls() {
+    return [...this.proxyUrls];
+  }
+
+  isProxyEnabled() {
+    return this.proxyEnabled;
   }
 
   getPort() {

--- a/src/geminiClient.js
+++ b/src/geminiClient.js
@@ -2,9 +2,10 @@ const https = require('https');
 const { URL } = require('url');
 
 class GeminiClient {
-  constructor(keyRotator, baseUrl = 'https://generativelanguage.googleapis.com') {
+  constructor(keyRotator, baseUrl = 'https://generativelanguage.googleapis.com', proxyManager = null) {
     this.keyRotator = keyRotator;
     this.baseUrl = baseUrl;
+    this.proxyManager = proxyManager;
   }
 
   async makeRequest(method, path, body, headers = {}, customStatusCodes = null, streaming = false) {
@@ -173,6 +174,16 @@ class GeminiClient {
       options.headers['Content-Length'] = Buffer.byteLength(bodyData);
     }
 
+    // Route through a rotating proxy if one is configured and enabled
+    if (this.proxyManager && this.proxyManager.isEnabled()) {
+      const picked = this.proxyManager.pick();
+      if (picked) {
+        options.agent = picked.agent;
+        options._proxyMasked = picked.maskedUrl;
+        console.log(`[GEMINI] Routing request via proxy ${picked.maskedUrl}`);
+      }
+    }
+
     return options;
   }
 
@@ -191,7 +202,8 @@ class GeminiClient {
           resolve({
             statusCode: res.statusCode,
             headers: res.headers,
-            data: data
+            data: data,
+            proxyUsed: options._proxyMasked || null
           });
         });
       });
@@ -219,7 +231,8 @@ class GeminiClient {
         resolve({
           statusCode: res.statusCode,
           headers: res.headers,
-          stream: res
+          stream: res,
+          proxyUsed: options._proxyMasked || null
         });
       });
 

--- a/src/openaiClient.js
+++ b/src/openaiClient.js
@@ -2,9 +2,10 @@ const https = require('https');
 const { URL } = require('url');
 
 class OpenAIClient {
-  constructor(keyRotator, baseUrl = 'https://api.openai.com') {
+  constructor(keyRotator, baseUrl = 'https://api.openai.com', proxyManager = null) {
     this.keyRotator = keyRotator;
     this.baseUrl = baseUrl;
+    this.proxyManager = proxyManager;
   }
 
   async makeRequest(method, path, body, headers = {}, customStatusCodes = null, streaming = false) {
@@ -130,6 +131,16 @@ class OpenAIClient {
       options.headers['Content-Length'] = Buffer.byteLength(bodyData);
     }
 
+    // Route through a rotating proxy if one is configured and enabled
+    if (this.proxyManager && this.proxyManager.isEnabled()) {
+      const picked = this.proxyManager.pick();
+      if (picked) {
+        options.agent = picked.agent;
+        options._proxyMasked = picked.maskedUrl;
+        console.log(`[OPENAI] Routing request via proxy ${picked.maskedUrl}`);
+      }
+    }
+
     return options;
   }
 
@@ -148,7 +159,8 @@ class OpenAIClient {
           resolve({
             statusCode: res.statusCode,
             headers: res.headers,
-            data: data
+            data: data,
+            proxyUsed: options._proxyMasked || null
           });
         });
       });
@@ -177,7 +189,8 @@ class OpenAIClient {
         resolve({
           statusCode: res.statusCode,
           headers: res.headers,
-          stream: res
+          stream: res,
+          proxyUsed: options._proxyMasked || null
         });
       });
 

--- a/src/proxyManager.js
+++ b/src/proxyManager.js
@@ -1,0 +1,352 @@
+const net = require('net');
+const tls = require('tls');
+const https = require('https');
+const { URL } = require('url');
+
+/**
+ * Proxy support with ZERO external dependencies.
+ *
+ * Supports two proxy types, auto-detected from the URL scheme:
+ *   - HTTP/HTTPS proxies via the CONNECT tunneling method
+ *       http://[user:pass@]host:port   https://[user:pass@]host:port
+ *   - SOCKS5 proxies (with optional username/password auth)
+ *       socks5://[user:pass@]host:port  (socks5h:// is treated the same)
+ *
+ * The upstream target is always reached over TLS (all provider clients use
+ * https.request), so after the tunnel is established the socket is wrapped in
+ * a TLS session to the target host.
+ *
+ * ProxyManager holds a list of proxies and rotates through them per request
+ * (round-robin), mirroring how KeyRotator rotates API keys.
+ */
+
+function splitAuth(auth) {
+  const i = auth.indexOf(':');
+  if (i === -1) return [auth, ''];
+  return [auth.slice(0, i), auth.slice(i + 1)];
+}
+
+/**
+ * Parse a proxy URL into its parts. Throws on an unusable URL.
+ * A bare `host:port` (no scheme) is assumed to be an HTTP proxy.
+ */
+function parseProxyUrl(raw) {
+  if (!raw || typeof raw !== 'string') {
+    throw new Error('Empty proxy URL');
+  }
+  let s = raw.trim();
+  if (!/^[a-z0-9]+:\/\//i.test(s)) {
+    s = 'http://' + s;
+  }
+
+  const u = new URL(s);
+  const scheme = u.protocol.replace(':', '').toLowerCase();
+
+  let type;
+  if (scheme === 'socks5' || scheme === 'socks' || scheme === 'socks5h') {
+    type = 'socks5';
+  } else if (scheme === 'http' || scheme === 'https') {
+    type = 'http';
+  } else {
+    throw new Error(`Unsupported proxy scheme "${scheme}" (use http, https, or socks5)`);
+  }
+
+  if (!u.hostname) {
+    throw new Error('Proxy URL is missing a host');
+  }
+
+  const auth = u.username
+    ? `${decodeURIComponent(u.username)}:${decodeURIComponent(u.password)}`
+    : null;
+
+  const defaultPort = type === 'socks5' ? 1080 : (u.protocol === 'https:' ? 443 : 80);
+
+  return {
+    type,
+    protocol: u.protocol, // 'http:' | 'https:' | 'socks5:'
+    hostname: u.hostname,
+    port: parseInt(u.port, 10) || defaultPort,
+    auth,
+  };
+}
+
+/**
+ * Establish a TCP (or TLS, for an https proxy) connection to the proxy and
+ * open a CONNECT tunnel to targetHost:targetPort. Calls cb(err, socket) with a
+ * raw duplex socket that is tunneled to the target (not yet TLS-wrapped).
+ */
+function connectHttp(proxy, targetHost, targetPort, cb) {
+  let settled = false;
+  const finish = (err, socket) => {
+    if (settled) return;
+    settled = true;
+    cb(err, err ? undefined : socket);
+  };
+
+  const onReady = () => {
+    const lines = [
+      `CONNECT ${targetHost}:${targetPort} HTTP/1.1`,
+      `Host: ${targetHost}:${targetPort}`,
+    ];
+    if (proxy.auth) {
+      const encoded = Buffer.from(proxy.auth).toString('base64');
+      lines.push(`Proxy-Authorization: Basic ${encoded}`);
+    }
+    lines.push('Connection: keep-alive', '', '');
+    socket.write(lines.join('\r\n'));
+  };
+
+  const connectOpts = { host: proxy.hostname, port: proxy.port };
+  const socket = proxy.protocol === 'https:'
+    ? tls.connect({ ...connectOpts, servername: proxy.hostname }, onReady)
+    : net.connect(connectOpts, onReady);
+
+  socket.once('error', (err) => finish(err));
+
+  let buffer = Buffer.alloc(0);
+  const onData = (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    const headerEnd = buffer.indexOf('\r\n\r\n');
+    if (headerEnd === -1) return; // wait for the full status/header block
+
+    socket.removeListener('data', onData);
+    const header = buffer.slice(0, headerEnd).toString('utf8');
+    const statusLine = header.split('\r\n')[0];
+    const match = statusLine.match(/^HTTP\/\d(?:\.\d)?\s+(\d+)/);
+    const status = match ? parseInt(match[1], 10) : 0;
+
+    if (status === 200) {
+      const leftover = buffer.slice(headerEnd + 4);
+      if (leftover.length > 0) socket.unshift(leftover);
+      finish(null, socket);
+    } else {
+      finish(new Error(`Proxy CONNECT rejected: ${statusLine || 'no response'}`));
+      socket.destroy();
+    }
+  };
+  socket.on('data', onData);
+}
+
+/**
+ * Perform a SOCKS5 handshake against the proxy and open a connection to
+ * targetHost:targetPort. Calls cb(err, socket) with the raw tunneled socket.
+ */
+function connectSocks5(proxy, targetHost, targetPort, cb) {
+  let settled = false;
+  const finish = (err, socket) => {
+    if (settled) return;
+    settled = true;
+    cb(err, err ? undefined : socket);
+  };
+
+  const socket = net.connect({ host: proxy.hostname, port: proxy.port });
+  socket.once('error', (err) => finish(err));
+
+  const [user, pass] = proxy.auth ? splitAuth(proxy.auth) : [null, null];
+  let stage = 'greeting';
+  let buffer = Buffer.alloc(0);
+
+  const sendConnect = () => {
+    const hostBuf = Buffer.from(targetHost, 'utf8');
+    const req = Buffer.concat([
+      Buffer.from([0x05, 0x01, 0x00, 0x03, hostBuf.length]),
+      hostBuf,
+      Buffer.from([(targetPort >> 8) & 0xff, targetPort & 0xff]),
+    ]);
+    stage = 'reply';
+    socket.write(req);
+  };
+
+  socket.once('connect', () => {
+    if (user != null) {
+      socket.write(Buffer.from([0x05, 0x02, 0x00, 0x02])); // offer no-auth + user/pass
+    } else {
+      socket.write(Buffer.from([0x05, 0x01, 0x00])); // offer no-auth only
+    }
+  });
+
+  const process = () => {
+    if (stage === 'greeting') {
+      if (buffer.length < 2) return;
+      const method = buffer[1];
+      buffer = buffer.slice(2);
+      if (method === 0x00) {
+        sendConnect();
+      } else if (method === 0x02) {
+        if (user == null) {
+          finish(new Error('SOCKS5 proxy requires authentication but none was provided'));
+          socket.destroy();
+          return;
+        }
+        const u = Buffer.from(user, 'utf8');
+        const p = Buffer.from(pass || '', 'utf8');
+        const authReq = Buffer.concat([
+          Buffer.from([0x01, u.length]), u,
+          Buffer.from([p.length]), p,
+        ]);
+        stage = 'auth';
+        socket.write(authReq);
+      } else {
+        finish(new Error('SOCKS5 proxy rejected all offered auth methods'));
+        socket.destroy();
+        return;
+      }
+      if (buffer.length > 0) process();
+      return;
+    }
+
+    if (stage === 'auth') {
+      if (buffer.length < 2) return;
+      const statusByte = buffer[1];
+      buffer = buffer.slice(2);
+      if (statusByte !== 0x00) {
+        finish(new Error('SOCKS5 authentication failed'));
+        socket.destroy();
+        return;
+      }
+      sendConnect();
+      if (buffer.length > 0) process();
+      return;
+    }
+
+    if (stage === 'reply') {
+      if (buffer.length < 4) return;
+      const rep = buffer[1];
+      const atyp = buffer[3];
+      let addrLen;
+      if (atyp === 0x01) addrLen = 4;
+      else if (atyp === 0x04) addrLen = 16;
+      else if (atyp === 0x03) {
+        if (buffer.length < 5) return;
+        addrLen = 1 + buffer[4];
+      } else {
+        finish(new Error(`SOCKS5 reply had unknown address type ${atyp}`));
+        socket.destroy();
+        return;
+      }
+      const totalLen = 4 + addrLen + 2;
+      if (buffer.length < totalLen) return;
+
+      if (rep !== 0x00) {
+        finish(new Error(`SOCKS5 connect failed (reply code ${rep})`));
+        socket.destroy();
+        return;
+      }
+      const leftover = buffer.slice(totalLen);
+      socket.removeListener('data', onData);
+      if (leftover.length > 0) socket.unshift(leftover);
+      finish(null, socket);
+    }
+  };
+
+  const onData = (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    process();
+  };
+  socket.on('data', onData);
+}
+
+/**
+ * An https.Agent that routes every connection through a single proxy.
+ * https.request calls createConnection() for us; we build the tunnel, then
+ * TLS-wrap it to the target host and hand the secure socket back.
+ */
+class ProxyAgent extends https.Agent {
+  constructor(proxyUrl, options = {}) {
+    super({ ...options, keepAlive: false, maxSockets: Infinity });
+    this.proxy = parseProxyUrl(proxyUrl);
+  }
+
+  createConnection(options, callback) {
+    const targetHost = options.host || options.hostname;
+    const targetPort = parseInt(options.port, 10) || 443;
+
+    const onTunnel = (err, rawSocket) => {
+      if (err) return callback(err);
+      const tlsOptions = {
+        host: targetHost,
+        servername: options.servername || targetHost,
+        socket: rawSocket,
+      };
+      // Forward standard TLS options from the request so custom CAs and
+      // rejectUnauthorized behave the same as a direct https.request.
+      for (const k of ['rejectUnauthorized', 'ca', 'cert', 'key', 'passphrase', 'pfx', 'ciphers', 'secureProtocol', 'ALPNProtocols']) {
+        if (options[k] !== undefined) tlsOptions[k] = options[k];
+      }
+      const tlsSocket = tls.connect(tlsOptions, () => callback(null, tlsSocket));
+      tlsSocket.once('error', (e) => callback(e));
+    };
+
+    if (this.proxy.type === 'socks5') {
+      connectSocks5(this.proxy, targetHost, targetPort, onTunnel);
+    } else {
+      connectHttp(this.proxy, targetHost, targetPort, onTunnel);
+    }
+  }
+}
+
+class ProxyManager {
+  constructor(proxyUrls = [], enabled = false) {
+    this.proxyUrls = (Array.isArray(proxyUrls) ? proxyUrls : [])
+      .map((u) => (u || '').trim())
+      .filter((u) => u.length > 0);
+    this.enabled = !!enabled && this.proxyUrls.length > 0;
+    this.rotationIndex = 0;
+    this._agentCache = new Map();
+  }
+
+  isEnabled() {
+    return this.enabled && this.proxyUrls.length > 0;
+  }
+
+  getProxyUrls() {
+    return [...this.proxyUrls];
+  }
+
+  getAgentFor(proxyUrl) {
+    if (!this._agentCache.has(proxyUrl)) {
+      this._agentCache.set(proxyUrl, new ProxyAgent(proxyUrl));
+    }
+    return this._agentCache.get(proxyUrl);
+  }
+
+  /**
+   * Round-robin pick the next proxy for a request. Returns
+   * { url, maskedUrl, agent, index } or null when disabled/empty.
+   */
+  pick() {
+    if (!this.isEnabled()) return null;
+    const index = this.rotationIndex % this.proxyUrls.length;
+    this.rotationIndex = (this.rotationIndex + 1) % this.proxyUrls.length;
+    const url = this.proxyUrls[index];
+    return {
+      url,
+      index,
+      maskedUrl: ProxyManager.maskProxyUrl(url),
+      agent: this.getAgentFor(url),
+    };
+  }
+
+  static parse(proxyUrl) {
+    return parseProxyUrl(proxyUrl);
+  }
+
+  static createAgent(proxyUrl) {
+    return new ProxyAgent(proxyUrl);
+  }
+
+  /** Hide credentials when a proxy URL is shown in logs or the UI. */
+  static maskProxyUrl(raw) {
+    try {
+      const p = parseProxyUrl(raw);
+      const cred = p.auth ? '***:***@' : '';
+      return `${p.protocol}//${cred}${p.hostname}:${p.port}`;
+    } catch (e) {
+      return raw;
+    }
+  }
+}
+
+module.exports = ProxyManager;
+module.exports.ProxyAgent = ProxyAgent;
+module.exports.parseProxyUrl = parseProxyUrl;

--- a/src/server.js
+++ b/src/server.js
@@ -1,9 +1,11 @@
 const http = require('http');
+const https = require('https');
 const { URL } = require('url');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const TelegramBot = require('./telegramBot');
+const ProxyManager = require('./proxyManager');
 
 class ProxyServer {
   constructor(config, geminiClient = null, openaiClient = null) {
@@ -245,6 +247,7 @@ class ProxyServer {
 
       // Extract key info from response
       const keyInfo = response._keyInfo || null;
+      const proxyUsed = response.proxyUsed || null;
 
       if (isStreaming && response.stream) {
         // Streaming response - pipe directly to client
@@ -287,13 +290,15 @@ class ProxyServer {
             responseData: streamedData,
             requestBody: body,
             streaming: true,
+            provider: providerName,
+            proxyUsed: proxyUsed,
             keyInfo: keyInfo
           });
 
           if (isApiCall) {
             const responseTime = Date.now() - startTime;
             const error = response.statusCode >= 400 ? `HTTP ${response.statusCode}` : null;
-            this.logApiRequest(requestId, req.method, path, providerName, response.statusCode, responseTime, error, clientIp, keyInfo);
+            this.logApiRequest(requestId, req.method, path, providerName, response.statusCode, responseTime, error, clientIp, keyInfo, proxyUsed);
           }
           console.log(`[REQ-${requestId}] Streaming response completed`);
         });
@@ -309,10 +314,13 @@ class ProxyServer {
         if (isApiCall) {
           const responseTime = Date.now() - startTime;
           const error = response.statusCode >= 400 ? `HTTP ${response.statusCode}` : null;
-          this.logApiRequest(requestId, req.method, path, providerName, response.statusCode, responseTime, error, clientIp, keyInfo);
+          this.logApiRequest(requestId, req.method, path, providerName, response.statusCode, responseTime, error, clientIp, keyInfo, proxyUsed);
         }
 
-        this.logApiResponse(requestId, response, body);
+        this.logApiResponse(requestId, response, body, {
+          method: req.method, endpoint: path, apiType: apiType.toUpperCase(),
+          provider: providerName, proxyUsed, keyInfo
+        });
         this.sendResponse(res, response);
       }
     } catch (error) {
@@ -427,10 +435,11 @@ class ProxyServer {
       const keyRotator = new this.KeyRotator(enabledKeys, provider.apiType);
       let client;
 
+      const proxyManager = this.config.getProxyManager();
       if (provider.apiType === 'openai') {
-        client = new this.OpenAIClient(keyRotator, provider.baseUrl);
+        client = new this.OpenAIClient(keyRotator, provider.baseUrl, proxyManager);
       } else if (provider.apiType === 'gemini') {
-        client = new this.GeminiClient(keyRotator, provider.baseUrl);
+        client = new this.GeminiClient(keyRotator, provider.baseUrl, proxyManager);
       } else {
         return null;
       }
@@ -598,20 +607,23 @@ class ProxyServer {
     }
   }
 
-  logApiResponse(requestId, response, requestBody = null) {
+  logApiResponse(requestId, response, requestBody = null, meta = {}) {
     const contentLength = response.headers['content-length'] || (response.data ? response.data.length : 0);
     const contentType = response.headers['content-type'] || 'unknown';
-    
+
     // Store response data for viewing
     this.storeResponseData(requestId, {
-      method: 'API_CALL',
-      endpoint: 'proxied_request',
-      apiType: 'LLM_API',
+      method: meta.method || 'API_CALL',
+      endpoint: meta.endpoint || 'proxied_request',
+      apiType: meta.apiType || 'LLM_API',
       status: response.statusCode,
       statusText: this.getStatusText(response.statusCode),
       contentType: contentType,
       responseData: response.data,
-      requestBody: requestBody
+      requestBody: requestBody,
+      provider: meta.provider || null,
+      proxyUsed: meta.proxyUsed || null,
+      keyInfo: meta.keyInfo || null
     });
     
     // Log basic response info to console only (structured logging handled in handleRequest)
@@ -748,6 +760,12 @@ class ProxyServer {
       await this.handleGetTelegramSettings(res);
     } else if (path === '/admin/api/telegram' && req.method === 'POST') {
       await this.handleUpdateTelegramSettings(res, body);
+    } else if (path === '/admin/api/proxy' && req.method === 'GET') {
+      await this.handleGetProxySettings(res);
+    } else if (path === '/admin/api/proxy' && req.method === 'POST') {
+      await this.handleUpdateProxySettings(res, body);
+    } else if (path === '/admin/api/proxy/test' && req.method === 'POST') {
+      await this.handleTestProxy(res, body);
     } else {
       this.sendError(res, 404, 'Not found');
     }
@@ -894,7 +912,7 @@ class ProxyServer {
 
       // Preserve _DISABLED, TELEGRAM_, and DEFAULT_STATUS_CODES entries from current env if not in new vars
       for (const [key, value] of Object.entries(currentEnvVars)) {
-        if ((key.endsWith('_DISABLED') || key.startsWith('TELEGRAM_') || key === 'DEFAULT_STATUS_CODES' || key === 'KEEP_ALIVE_MINUTES') && !(key in finalEnvVars)) {
+        if ((key.endsWith('_DISABLED') || key.startsWith('TELEGRAM_') || key.startsWith('PROXY_') || key === 'DEFAULT_STATUS_CODES' || key === 'KEEP_ALIVE_MINUTES') && !(key in finalEnvVars)) {
           finalEnvVars[key] = value;
         }
       }
@@ -1098,7 +1116,7 @@ class ProxyServer {
   }
   
   
-  logApiRequest(requestId, method, endpoint, provider, status = null, responseTime = null, error = null, clientIp = null, keyInfo = null) {
+  logApiRequest(requestId, method, endpoint, provider, status = null, responseTime = null, error = null, clientIp = null, keyInfo = null, proxyUsed = null) {
     const logEntry = {
       timestamp: new Date().toISOString(),
       requestId: requestId || 'unknown',
@@ -1110,7 +1128,8 @@ class ProxyServer {
       error: error,
       clientIp: clientIp,
       keyUsed: keyInfo ? keyInfo.keyUsed : null,
-      failedKeys: keyInfo ? keyInfo.failedKeys : []
+      failedKeys: keyInfo ? keyInfo.failedKeys : [],
+      proxyUsed: proxyUsed || null
     };
     
     // Add to buffer (keep last 100 entries in RAM only)
@@ -1362,6 +1381,155 @@ class ProxyServer {
   }
 
   /**
+   * Return current outbound-proxy settings.
+   * Full URLs (incl. credentials) are returned so the admin can edit them —
+   * consistent with the existing /admin/api/env-file endpoint, and gated by
+   * admin authentication.
+   */
+  async handleGetProxySettings(res) {
+    try {
+      const envPath = path.join(process.cwd(), '.env');
+      const envVars = this.config.parseEnvFile(fs.readFileSync(envPath, 'utf8'));
+
+      const proxies = (envVars.PROXY_URLS || '')
+        .split(',')
+        .map(u => u.trim())
+        .filter(u => u.length > 0)
+        .map(url => ({ url, masked: ProxyManager.maskProxyUrl(url) }));
+
+      const enabled = (envVars.PROXY_ENABLED || '').trim().toLowerCase() === 'true';
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ enabled, proxies }));
+    } catch (error) {
+      this.sendError(res, 500, 'Failed to read proxy settings');
+    }
+  }
+
+  /**
+   * Update outbound-proxy settings.
+   * Body: { enabled: boolean, proxies: string[] }
+   */
+  async handleUpdateProxySettings(res, body) {
+    try {
+      const { enabled, proxies } = JSON.parse(body);
+
+      const list = Array.isArray(proxies)
+        ? proxies.map(p => String(p).trim()).filter(p => p.length > 0)
+        : [];
+
+      // Validate every proxy URL before persisting anything
+      const invalid = [];
+      for (const url of list) {
+        try {
+          ProxyManager.parse(url);
+        } catch (e) {
+          invalid.push(`${ProxyManager.maskProxyUrl(url)} (${e.message})`);
+        }
+      }
+      if (invalid.length > 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: false, error: `Invalid proxy URL(s): ${invalid.join('; ')}` }));
+        return;
+      }
+
+      const envPath = path.join(process.cwd(), '.env');
+      const envVars = this.config.parseEnvFile(fs.readFileSync(envPath, 'utf8'));
+
+      if (list.length > 0) {
+        envVars.PROXY_URLS = list.join(',');
+      } else {
+        delete envVars.PROXY_URLS;
+      }
+
+      const enable = !!enabled && list.length > 0;
+      if (enable) {
+        envVars.PROXY_ENABLED = 'true';
+      } else {
+        delete envVars.PROXY_ENABLED;
+      }
+
+      this.writeEnvFile(envVars);
+      this.config.loadConfig();
+      this.reinitializeClients();
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true, count: list.length, enabled: enable }));
+    } catch (error) {
+      this.sendError(res, 500, 'Failed to update proxy settings: ' + error.message);
+    }
+  }
+
+  /**
+   * Test a single proxy by fetching the current outbound IP through it.
+   * Body: { proxy: string }
+   */
+  async handleTestProxy(res, body) {
+    try {
+      const { proxy } = JSON.parse(body);
+      if (!proxy || !String(proxy).trim()) {
+        this.sendError(res, 400, 'Missing proxy URL');
+        return;
+      }
+      const result = await this.testProxyConnection(String(proxy).trim());
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result));
+    } catch (error) {
+      this.sendError(res, 500, 'Failed to test proxy: ' + error.message);
+    }
+  }
+
+  /**
+   * Route a request to an IP-echo service through the given proxy and return
+   * the observed outbound IP. Uses only Node built-ins via ProxyManager.
+   */
+  testProxyConnection(proxyUrl) {
+    return new Promise((resolve) => {
+      let agent;
+      try {
+        agent = ProxyManager.createAgent(proxyUrl);
+      } catch (e) {
+        return resolve({ success: false, error: 'Invalid proxy URL: ' + e.message });
+      }
+
+      const startTime = Date.now();
+      const options = {
+        hostname: 'api.ipify.org',
+        port: 443,
+        path: '/?format=json',
+        method: 'GET',
+        agent,
+        headers: { 'Accept': 'application/json', 'User-Agent': 'rotato-proxy-test' },
+        timeout: 15000,
+      };
+
+      const req = https.request(options, (r) => {
+        let data = '';
+        r.on('data', (c) => { data += c; });
+        r.on('end', () => {
+          const ms = Date.now() - startTime;
+          let ip = null;
+          try { ip = JSON.parse(data).ip; } catch (e) { ip = data.trim(); }
+          if (r.statusCode === 200 && ip) {
+            resolve({ success: true, ip, ms, masked: ProxyManager.maskProxyUrl(proxyUrl) });
+          } else {
+            resolve({ success: false, error: `Unexpected response (HTTP ${r.statusCode})`, ms });
+          }
+        });
+      });
+
+      req.on('timeout', () => {
+        req.destroy();
+        resolve({ success: false, error: 'Timed out after 15s (proxy unreachable or too slow)' });
+      });
+      req.on('error', (e) => {
+        resolve({ success: false, error: e.message });
+      });
+      req.end();
+    });
+  }
+
+  /**
    * Write env vars back to .env file (shared helper)
    */
   writeEnvFile(envVars) {
@@ -1464,19 +1632,21 @@ class ProxyServer {
     // Clear all provider clients
     this.providerClients.clear();
     
+    const proxyManager = this.config.getProxyManager();
+
     // Reinitialize legacy clients for backward compatibility
     if (this.config.hasGeminiKeys()) {
       const geminiKeyRotator = new this.KeyRotator(this.config.getGeminiApiKeys(), 'gemini');
-      this.geminiClient = new this.GeminiClient(geminiKeyRotator, this.config.getGeminiBaseUrl());
+      this.geminiClient = new this.GeminiClient(geminiKeyRotator, this.config.getGeminiBaseUrl(), proxyManager);
       console.log('[SERVER] Legacy Gemini client reinitialized');
     } else {
       this.geminiClient = null;
       console.log('[SERVER] Legacy Gemini client disabled (no keys available)');
     }
-    
+
     if (this.config.hasOpenaiKeys()) {
       const openaiKeyRotator = new this.KeyRotator(this.config.getOpenaiApiKeys(), 'openai');
-      this.openaiClient = new this.OpenAIClient(openaiKeyRotator, this.config.getOpenaiBaseUrl());
+      this.openaiClient = new this.OpenAIClient(openaiKeyRotator, this.config.getOpenaiBaseUrl(), proxyManager);
       console.log('[SERVER] Legacy OpenAI client reinitialized');
     } else {
       this.openaiClient = null;


### PR DESCRIPTION
Proxy support (zero external deps, Node built-ins only):
- New ProxyManager/ProxyAgent: HTTP CONNECT tunneling + SOCKS5 (with optional auth), auto-detected from URL scheme. Rotates a list of proxies round-robin per request, mirroring the API key rotator.
- Config loads PROXY_ENABLED / PROXY_URLS; clients route through the picked proxy and record the masked proxy on each response.
- Admin panel: Proxy tab to manage the list, enable routing, and test each proxy (shows outbound IP). Settings moved from a modal into a tab.

Logs UX:
- Replaced the single-line terminal dump with a filterable table (search, provider/status/routing filters, live auto-refresh).
- Every request now shows which proxy (and key) served it.

Response viewer dialog:
- Color-coded status badge, method + endpoint, metadata chips (provider, type, size, key, proxy), syntax-highlighted JSON, Response/Request tabs, Wrap + Copy, Esc/click-out to close.
- Backend stores richer per-response metadata to feed the dialog.