### PR TITLE
Fix deleted provider reappearing after refresh

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -1961,6 +1961,17 @@
                 }
             });
 
+            // Drop ghost providers: entries that carry no API keys, no base URL and
+            // no access key are just a stray _DISABLED flag left over from an old
+            // delete — they must never render as a real provider.
+            for (const k of Object.keys(providers)) {
+                const p = providers[k];
+                const hasKeys = Array.isArray(p.keys) && p.keys.length > 0;
+                if (!hasKeys && !p.baseUrl && !p.accessKey) {
+                    delete providers[k];
+                }
+            }
+
             // Ordering: disabled providers sink to the bottom, but ONLY on a fresh
             // page load. Within a session we preserve the current on-screen order,
             // so toggling a provider off leaves it in place until the next load.

--- a/src/server.js
+++ b/src/server.js
@@ -918,7 +918,17 @@ class ProxyServer {
 
       // Preserve _DISABLED, TELEGRAM_, and DEFAULT_STATUS_CODES entries from current env if not in new vars
       for (const [key, value] of Object.entries(currentEnvVars)) {
-        if ((key.endsWith('_DISABLED') || key.startsWith('TELEGRAM_') || key.startsWith('PROXY_') || key === 'DEFAULT_STATUS_CODES' || key === 'KEEP_ALIVE_MINUTES') && !(key in finalEnvVars)) {
+        if (key in finalEnvVars) continue;
+
+        if (key.endsWith('_DISABLED')) {
+          // Only preserve a provider's disabled flag if that provider still exists
+          // (i.e. its API keys are present in the new payload). Otherwise a deleted
+          // provider's DISABLED flag would resurrect it as a keyless ghost on reload.
+          const apiKeysKey = key.replace(/_DISABLED$/, '_API_KEYS');
+          if (apiKeysKey in finalEnvVars) {
+            finalEnvVars[key] = value;
+          }
+        } else if (key.startsWith('TELEGRAM_') || key.startsWith('PROXY_') || key === 'DEFAULT_STATUS_CODES' || key === 'KEEP_ALIVE_MINUTES') {
           finalEnvVars[key] = value;
         }
       }
@@ -1633,7 +1643,9 @@ class ProxyServer {
           if (p.accessKey) envContent += `${p.apiType}_${p.providerName}_ACCESS_KEY=${p.accessKey}\n`;
           if (p.defaultModel) envContent += `${p.apiType}_${p.providerName}_DEFAULT_MODEL=${p.defaultModel}\n`;
           if (p.modelHistory) envContent += `${p.apiType}_${p.providerName}_MODEL_HISTORY=${p.modelHistory}\n`;
-          if (p.disabled && p.disabled === 'true') envContent += `${p.apiType}_${p.providerName}_DISABLED=true\n`;
+          // Only persist a disabled flag for a provider that actually has keys —
+          // an orphaned DISABLED flag would otherwise render as a keyless ghost provider.
+          if (p.disabled === 'true' && p.keys) envContent += `${p.apiType}_${p.providerName}_DISABLED=true\n`;
           envContent += '\n';
         }
       }


### PR DESCRIPTION
Deleting a provider left its DISABLED flag behind, resurrecting it as a keyless ghost on reload. Three defensive fixes:

- handleUpdateEnvVars: only preserve a provider's _DISABLED flag when that provider's _API_KEYS is still present in the payload, so a deleted provider's flag is dropped instead of re-added.
- writeEnvFile: never persist a _DISABLED line for a provider with no keys, cleaning up any already-orphaned flags on the next write.
- renderProviders: skip ghost entries that have no keys, base URL or access key (a stray disabled flag) so they never render as a real provider.